### PR TITLE
Update Linters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,4 +2,3 @@ AllCops:
   Exclude:
     - "bin/**/*"
     - "db/schema.rb"
-  TargetVersion: 2.4.1

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,4 +1,11 @@
 linters:
+  ElsePlacement:
+    enabled: true
+    style: new_line
+  NestingDepth:
+    enabled: true
+    max_depth: 3
+    ignore_parent_selectors: false
   StringQuotes:
     enabled: true
     style: single_quotes


### PR DESCRIPTION
- Rubocop: Remove TargetVersion (already specified in .ruby-version)
- SCSS:
  - Else-statement should be on a new line (rather than same line as
    closing bracket of if-statement)
  - Allow nesting up to three levels