### PR TITLE
Modify templates to use '=' instead of '=='

### DIFF
--- a/app/views/application/_navbar.slim
+++ b/app/views/application/_navbar.slim
@@ -2,5 +2,5 @@ nav.primary-color.primary-color-text
   .container
     .nav-wrapper
       .brand-logo
-        == image_tag 'logo.svg'
+        = image_tag 'logo.svg'
         | Upshift One

--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -2,13 +2,13 @@ doctype html
 html
   head
     title Create Change Together - Upshift One
-    == csrf_meta_tags
+    = csrf_meta_tags
 
-    == stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    == javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
     meta name='viewport' content='width=device-width, initial-scale=1.0'
 
   body class=[controller_action_identifier, color_scheme]
-    == render 'navbar'
-    == yield
+    = render 'navbar'
+    = yield

--- a/app/views/static/index.slim
+++ b/app/views/static/index.slim
@@ -23,7 +23,7 @@
           comments. Share ideas, learn from others, and collaborate with your
           team and beyond.
     .col.s12.m6.l4.push-l2.center-align
-      == image_tag 'static/collaboration.svg', class: 'responsive-img'
+      = image_tag 'static/collaboration.svg', class: 'responsive-img'
 
   .spacing.h64px
 
@@ -38,7 +38,7 @@
           your mind later, you can review previous versions and revert back any
           time.
     .col.s12.m6.pull-m6.l4.pull-l3.center-align
-      == image_tag 'static/focus.svg', class: 'responsive-img'
+      = image_tag 'static/focus.svg', class: 'responsive-img'
 
   .spacing.h64px
 
@@ -51,7 +51,7 @@
           and resources, search similar projects, identify
           collaborators, and make new friends.
     .col.s12.m6.l4.push-l2.center-align
-      == image_tag 'static/community.svg', class: 'responsive-img'
+      = image_tag 'static/community.svg', class: 'responsive-img'
 
   .spacing.h64px
 


### PR DESCRIPTION
According to Slim Templating docs, use '=' for output that you want to
be HTML escaped and use '==' for output that you do not want to have
HTML escaped. Using '=' we are on the safer side (making unescaped HTML
the exception rather than the default).