### PR TITLE
Disable JavaScript

### DIFF
--- a/app/views/layouts/application.slim
+++ b/app/views/layouts/application.slim
@@ -5,7 +5,7 @@ html
     = csrf_meta_tags
 
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    / javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
 
     meta name='viewport' content='width=device-width, initial-scale=1.0'
 


### PR DESCRIPTION
We will first build a non-JS based website without Turbolinks and MaterialJS.
This ensures that our site is fully non-JS compatible. It also focuses our
resources on development rather than maintaining compatibility.