### PR TITLE
Fix: Rename vertical spacing class

### DIFF
--- a/app/assets/stylesheets/shared.scss
+++ b/app/assets/stylesheets/shared.scss
@@ -52,7 +52,7 @@ nav .brand-logo {
 // Add a set amount of vertical spacing between elements
 // Usage: div.spacing with h16, h32, ..., h64, h128
 @each $factor in 1, 2, 3, 4, 8 {
-  div.spacing.h#{$factor * $base-unit} {
+  div.spacing.v#{$factor * $base-unit} {
     display: block;
     height: $factor * $base-unit;
   }

--- a/app/views/static/index.slim
+++ b/app/views/static/index.slim
@@ -9,9 +9,9 @@
         make a difference.
     .section
       button.btn-large.disabled Coming Soon
-    .spacing.h48px
+    .spacing.v48px
 
-.spacing.h64px
+.spacing.v64px
 
 .container
   .row
@@ -25,7 +25,7 @@
     .col.s12.m6.l4.push-l2.center-align
       = image_tag 'static/collaboration.svg', class: 'responsive-img'
 
-  .spacing.h64px
+  .spacing.v64px
 
   .row
     .col.s12.m6.push-m6.l4.push-l6
@@ -40,7 +40,7 @@
     .col.s12.m6.pull-m6.l4.pull-l3.center-align
       = image_tag 'static/focus.svg', class: 'responsive-img'
 
-  .spacing.h64px
+  .spacing.v64px
 
   .row
     .col.s12.m6.l4.push-l1
@@ -53,7 +53,7 @@
     .col.s12.m6.l4.push-l2.center-align
       = image_tag 'static/community.svg', class: 'responsive-img'
 
-  .spacing.h64px
+  .spacing.v64px
 
 .hero.black.white-text
   .container.center-align


### PR DESCRIPTION
Vertical spacing class should follow the format v..px to symbolize 'vertical' (rather than h..px). The use of h..px was an accident.