### PR TITLE
SCSS-Lint: Exclude leading zeros

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -11,3 +11,6 @@ linters:
   ElsePlacement:
     enabled: true
     style: new_line
+  LeadingZero:
+    enabled: true
+    style: exclude_zero


### PR DESCRIPTION
Do not recommend leading zeros for non-integer values. This is the default but we are making it explicit since Hound does not have it as its default value.