### PR TITLE
Account-user relationship cannot be altered

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,13 @@
 # to other users, such as the user's name (as opposed to an account's email and
 # password, for example)
 class User < ApplicationRecord
+  # Associations
   belongs_to :account
 
+  # Attributes
+  # Do not allow account change
+  attr_readonly :account_id
+
+  # Validations
   validates :name, presence: true
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe User, type: :model do
     it { is_expected.to belong_to(:account) }
   end
 
+  describe 'attributes' do
+    it { is_expected.to have_readonly_attribute(:account_id) }
+  end
+
   describe 'validations' do
     it do
       is_expected.to validate_presence_of(:account).with_message 'must exist'


### PR DESCRIPTION
Mark account_id as readonly on User model to prevent changes in the account-user relationship.