### PR TITLE
Devise: Prompt login when unauthenticated

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
 
   # override sign in redirect (Devise)
   def after_sign_in_path_for(resource)
-    profile_path resource.user
+    stored_location_for(resource) || profile_path(resource.user)
   end
 
   protected

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -14,7 +14,7 @@ en:
       last_attempt: "You have one more attempt before your account is locked."
       not_found_in_database: "Invalid email or password."
       timeout: "Your session expired. Please sign in again to continue."
-      unauthenticated: "You need to sign in or sign up before continuing."
+      unauthenticated: "You need to log in or register before continuing."
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,9 @@ Rails.application.routes.draw do
           :as       => :destroy_session
   end
 
+  # Redirect to login path when user is unauthenticated
+  get '/login' => 'devise/sessions#new', :as => :new_account_session
+
   # Routes for user profiles (must be last)
   get '/:handle' => 'profiles#show', as: :profile
 

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -18,9 +18,27 @@ feature 'Session' do
 
     # then I should be signed in
     expect(page).to have_text 'Signed in successfully'
-
     # and I should be on my profile page
     expect(page).to have_current_path "/#{account.user.username}"
+  end
+
+  scenario 'User is redirected back after being prompted for authentication' do
+    # given I have an account but I am not logged in
+    account = create :account
+
+    # when I visit my account settings
+    visit edit_account_path
+    # and I am prompted to login
+    expect(page).to have_current_path new_session_path
+    # and I log in
+    fill_in 'Email', with: account.email
+    fill_in 'Password', with: account.password
+    click_on 'Log in'
+
+    # then I should be signed in
+    expect(page).to have_text 'Signed in successfully'
+    # and I should be back to the account page
+    expect(page).to have_current_path edit_account_path
   end
 
   scenario 'User can log out' do

--- a/spec/routing/session_routing_spec.rb
+++ b/spec/routing/session_routing_spec.rb
@@ -15,4 +15,8 @@ RSpec.describe 'routes for sessions', type: :routing do
     expect(destroy_session_path).to eq '/logout'
     expect(get: '/logout').to route_to 'devise/sessions#destroy'
   end
+
+  it 'has a new_account_session_path for Devise' do
+    expect(new_account_session_path).to eq new_session_path
+  end
 end


### PR DESCRIPTION
When user visits page for which authentication is required, redirect them to the login page. Upon successful login, redirect user back to the page they originally requested.