### PR TITLE
Fix: Guardfile configuration for view specs

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -10,7 +10,7 @@ guard :rspec, cmd: 'bundle exec rspec' do
     "spec/#{m[1]}_spec.rb"
   end
   watch(%r{^app/(.*)(\.erb|\.haml|\.slim)$}) do |m|
-    "spec/#{m[1]}#{m[2]}_spec.rb"
+    "spec/#{m[1]}_spec.rb"
   end
   watch(%r{^lib/(.+)\.rb$}) do |m|
     "spec/lib/#{m[1]}_spec.rb"


### PR DESCRIPTION
Run view spec when template is updated. The file name for view spec should not include the file ending. It should just be 'show_spec.rb' rather than 'show.html.erb_spec.rb' or 'show.slim_spec.rb'.