### PR TITLE
Fix: Styling for form input placeholders

### DIFF
--- a/app/assets/stylesheets/shared/forms.scss
+++ b/app/assets/stylesheets/shared/forms.scss
@@ -8,6 +8,8 @@
 
 // Placeholders
 ::placeholder {
+  color: currentColor;
   font-size: .8em;
   font-style: italic;
+  opacity: .5;
 }

--- a/app/assets/stylesheets/shared/forms.scss
+++ b/app/assets/stylesheets/shared/forms.scss
@@ -8,6 +8,6 @@
 
 // Placeholders
 ::placeholder {
-  font-size: .8rem;
+  font-size: .8em;
   font-style: italic;
 }


### PR DESCRIPTION
Style placeholders to resemble parent input element in terms of color and size.