### PR TITLE
Projects can be found by ID

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -46,8 +46,15 @@ class Project < ApplicationRecord
             unless: proc { |project| project.errors[:slug].any? }
 
   # Find a project by profile handle and project slug
-  def self.find(profile_handle, project_slug)
-    Profile.find(profile_handle).projects.find_by_slug! project_slug
+  # Also allows finding by ID, so that #reload still works
+  def self.find(id_or_profile_handle, project_slug = nil)
+    if project_slug.nil?
+      # find by ID
+      find_by_id! id_or_profile_handle
+    else
+      # find by handle and slug
+      Profile.find(id_or_profile_handle).projects.find_by_slug! project_slug
+    end
   end
 
   # Trim whitespaces around title

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -92,6 +92,14 @@ RSpec.describe Project, type: :model do
       before { project.destroy }
       it { expect { method }.to raise_error ActiveRecord::RecordNotFound }
     end
+
+    context 'when project slug is not passed' do
+      subject(:method) { Project.find(project.id) }
+
+      it 'finds project by ID' do
+        is_expected.to eq project
+      end
+    end
   end
 
   describe '#title=' do


### PR DESCRIPTION
Extend Project.find method to restore its use of finding records by ID. This allows us to use methods, such as #reload, that depend on the original behavior of .find.