### PR TITLE
Modelize VersionControl::File

### DIFF
--- a/app/models/concerns/version_control.rb
+++ b/app/models/concerns/version_control.rb
@@ -10,10 +10,12 @@ module VersionControl
     after_create do
       begin
         create_repository
-        files.create('Overview',
-                     'Welcome to my new project!',
-                     'Initial Contribution',
-                     owner)
+        files.create(
+          name:             'Overview',
+          content:          'Welcome to my new project!',
+          revision_summary: 'Initial Contribution',
+          revision_author:  owner
+        )
       rescue
         # Do not persist object if any errors occur while creating repository
         raise ActiveRecord::Rollback

--- a/app/models/version_control/file.rb
+++ b/app/models/version_control/file.rb
@@ -147,6 +147,15 @@ module VersionControl
       return_value
     end
 
+    # Update attributes and attempt to save a new revision of file
+    def update(params = {})
+      (self.class.dirty_tracked_attributes +
+       self.class.accessor_attributes).each do |attribute|
+        send "#{attribute}=", params[attribute] if params[attribute]
+      end
+      save
+    end
+
     # Write the content to a new blob in repository
     def write_content_to_repository
       @oid = repository.write content, :blob

--- a/app/models/version_control/file.rb
+++ b/app/models/version_control/file.rb
@@ -5,17 +5,91 @@ module VersionControl
   class File
     include ActiveModel::Validations
 
-    attr_reader :oid, :name, :collection
+    attr_accessor :name, :collection, :content,
+                  :revision_summary, :revision_author
+    attr_reader   :oid
+
+    delegate :repository, to: :collection
+
+    # Validations
+    validates :revision_author,   presence: true, on: :create
+    validates :revision_summary,  presence: true, on: :create
+    validates :name,              presence: true, on: :create
+    validates :name,
+              format: {
+                without: %r{/},
+                message: 'must not contain forward slashes (/)'
+              },
+              on: :create
+    validate :name_must_be_case_insensitively_unique, on: :create
+
+    # Initialize a new file and commit to repository
+    # Return reference to new file
+    def self.create(params)
+      file = new params
+
+      # validate the file
+      return false if file.invalid?
+
+      # save the file
+      file.write_content_to_repository
+      file.send :commit do |f|
+        f.repository.index.add path: f.name, oid: f.oid, mode: 0o100644
+      end
+
+      # return the file instance
+      file
+    end
 
     def initialize(params = {})
-      @oid        = params[:oid]
-      @name       = params[:name]
-      @collection = params[:collection]
+      @oid                = params[:oid]
+      @name               = params[:name]
+      @collection         = params[:collection]
+      @content            = params[:content]
+      @revision_summary   = params[:revision_summary]
+      @revision_author    = params[:revision_author]
     end
 
     # Return the file's content
     def content
-      @content ||= collection.lookup(oid).content
+      @content ||= repository.lookup(oid).content
     end
+
+    # Write the content to a new blob in repository
+    def write_content_to_repository
+      @oid = repository.write content, :blob
+    end
+
+    private
+
+    # Wrapper for actions that are identical for commits
+    def commit
+      # remove file from index/stage and commit
+      repository.reset_index!
+
+      # execute block
+      yield self
+
+      # make a commit
+      commit_id = repository.commit revision_summary, revision_author
+
+      # clear revision author & summary
+      if commit_id
+        self.revision_author = nil
+        self.revision_summary = nil
+      end
+
+      commit_id
+    end
+
+    # Validate that the name is case sensitively unique within the version
+    # controlled repository
+    # rubocop:disable Style/GuardClause
+    def name_must_be_case_insensitively_unique
+      if collection.reload!.exists?(name)
+        errors.add :name, 'has already been taken'
+      end
+    end
+    # rubocop:enable Style/GuardClause
   end
 end

--- a/app/models/version_control/file.rb
+++ b/app/models/version_control/file.rb
@@ -3,6 +3,8 @@
 module VersionControl
   # A single version controlled file
   class File
+    include ActiveModel::Validations
+
     attr_reader :oid, :name, :collection
 
     def initialize(params = {})

--- a/app/models/version_control/file.rb
+++ b/app/models/version_control/file.rb
@@ -36,6 +36,7 @@ module VersionControl
       file.send :commit do |f|
         f.repository.index.add path: f.name, oid: f.oid, mode: 0o100644
       end
+      file.instance_variable_set :@persisted, true
 
       # return the file instance
       file
@@ -48,11 +49,17 @@ module VersionControl
       @content            = params[:content]
       @revision_summary   = params[:revision_summary]
       @revision_author    = params[:revision_author]
+      @persisted          = params[:persisted] || false
     end
 
     # Return the file's content
     def content
       @content ||= repository.lookup(oid).content
+    end
+
+    # Return true if the file is persisted
+    def persisted?
+      @persisted
     end
 
     # Write the content to a new blob in repository

--- a/app/models/version_control/file_collection.rb
+++ b/app/models/version_control/file_collection.rb
@@ -53,6 +53,7 @@ module VersionControl
     end
 
     # Reload files from last commit on master
+    # rubocop:disable Metrics/MethodLength
     def reload!
       @files = []
 
@@ -62,6 +63,7 @@ module VersionControl
       # initialize files
       @repository.branches['master'].target.tree.each do |file|
         @files << VersionControl::File.new(
+          persisted:  true,
           collection: self,
           name:       file[:name],
           oid:        file[:oid].to_s
@@ -70,5 +72,6 @@ module VersionControl
 
       self
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/app/models/version_control/file_collection.rb
+++ b/app/models/version_control/file_collection.rb
@@ -5,8 +5,7 @@ module VersionControl
   class FileCollection
     include Enumerable
 
-    # Delegate lookup, so that File can look up its contents
-    delegate :lookup, to: :@repository
+    attr_reader :repository
 
     # Alias #find to #find_by so that we can override find
     alias find_by find
@@ -28,23 +27,16 @@ module VersionControl
       @files.each(&block)
     end
 
-    # Create a new file
-    # Return true on success
-    # Return false on error
-    def create(name, content, message, author)
-      # Write the file
-      blob_oid = @repository.write content, :blob
+    # Create a new file and return it
+    def create(params)
+      # Create new file
+      file = VersionControl::File.create params.merge(collection: self)
 
-      # Stage the file
-      @repository.reset_index!
-      @repository.index.add path: name, oid: blob_oid, mode: 0o100644
-
-      # Commit to master
-      return false unless @repository.commit message, author
-
-      # Reload self
+      # Reload files in collection
       reload!
-      true
+
+      # Return reference to new file
+      file
     end
 
     # Check for the existence of a file by name (case insensitive)

--- a/spec/factories/version_control/file.rb
+++ b/spec/factories/version_control/file.rb
@@ -2,8 +2,6 @@
 
 FactoryGirl.define do
   factory :vc_file, class: VersionControl::File do
-    skip_create
-
     name              { Faker::File.unique.file_name('', nil, nil, '') }
     collection        { build :vc_file_collection }
     content           { Faker::Lorem.paragraphs.join('\n\n') }
@@ -11,19 +9,6 @@ FactoryGirl.define do
     revision_author   { build :user }
     revision_summary  { Faker::Simpsons.quote }
     persisted         { false }
-
-    # persist the file to the repository and assign oid
-    before(:create) do |file|
-      file.collection.create(
-        name: file.name,
-        content: file.content,
-        revision_summary: file.revision_summary,
-        revision_author: file.revision_author
-      )
-      file.instance_variable_set :@oid, file.collection.find(file.name).oid
-      file.instance_variable_set :@persisted, true
-      file.send :changes_applied
-    end
 
     initialize_with do
       new(

--- a/spec/factories/version_control/file.rb
+++ b/spec/factories/version_control/file.rb
@@ -4,27 +4,33 @@ FactoryGirl.define do
   factory :vc_file, class: VersionControl::File do
     skip_create
 
-    transient do
-      content     { Faker::Lorem.paragraphs.join('\n\n') }
-      message     { Faker::Simpsons.quote }
-      author      { build :user }
-    end
-
-    name          { Faker::File.unique.file_name('', nil, nil, '') }
-    collection    { build :vc_file_collection }
-    oid           { Faker::Crypto.sha1 }
+    name              { Faker::File.unique.file_name('', nil, nil, '') }
+    collection        { build :vc_file_collection }
+    content           { Faker::Lorem.paragraphs.join('\n\n') }
+    oid               { Faker::Crypto.sha1 }
+    revision_author   { build :user }
+    revision_summary  { Faker::Simpsons.quote }
 
     # persist the file to the repository and assign oid
-    before(:create) do |file, transient|
+    before(:create) do |file|
       file.collection.create(
-        file.name,
-        transient.content,
-        transient.message,
-        transient.author
+        name: file.name,
+        content: file.content,
+        revision_summary: file.revision_summary,
+        revision_author: file.revision_author
       )
       file.instance_variable_set :@oid, file.collection.find(file.name).oid
     end
 
-    initialize_with { new name: name, collection: collection, oid: oid }
+    initialize_with do
+      new(
+        name: name,
+        collection: collection,
+        oid: oid,
+        content: content,
+        revision_summary: revision_summary,
+        revision_author: revision_author
+      )
+    end
   end
 end

--- a/spec/factories/version_control/file.rb
+++ b/spec/factories/version_control/file.rb
@@ -22,6 +22,7 @@ FactoryGirl.define do
       )
       file.instance_variable_set :@oid, file.collection.find(file.name).oid
       file.instance_variable_set :@persisted, true
+      file.send :changes_applied
     end
 
     initialize_with do

--- a/spec/factories/version_control/file.rb
+++ b/spec/factories/version_control/file.rb
@@ -10,6 +10,7 @@ FactoryGirl.define do
     oid               { Faker::Crypto.sha1 }
     revision_author   { build :user }
     revision_summary  { Faker::Simpsons.quote }
+    persisted         { false }
 
     # persist the file to the repository and assign oid
     before(:create) do |file|
@@ -20,6 +21,7 @@ FactoryGirl.define do
         revision_author: file.revision_author
       )
       file.instance_variable_set :@oid, file.collection.find(file.name).oid
+      file.instance_variable_set :@persisted, true
     end
 
     initialize_with do
@@ -29,7 +31,8 @@ FactoryGirl.define do
         oid: oid,
         content: content,
         revision_summary: revision_summary,
-        revision_author: revision_author
+        revision_author: revision_author,
+        persisted: persisted
       )
     end
   end

--- a/spec/models/shared_examples/having_dirty_tracked_attribute.rb
+++ b/spec/models/shared_examples/having_dirty_tracked_attribute.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'having a dirty-tracked attribute' do |attribute|
+  let!(:new_value)  { 'new attribute value' }
+  let!(:old_value)  { subject.send attribute }
+  before            { subject.send "#{attribute}=", new_value }
+
+  it 'equals new attribute value' do
+    expect(subject.send(attribute)).to eq new_value
+  end
+
+  it '_was equals old attribute value' do
+    expect(subject.send("#{attribute}_was")).to eq old_value
+  end
+
+  it 'has been changed' do
+    expect(subject.send("#{attribute}_changed?")).to be true
+  end
+
+  it 'can be restored' do
+    subject.send "restore_#{attribute}!"
+    expect(subject.send(attribute)).to eq old_value
+  end
+end

--- a/spec/models/version_control/file_collection_spec.rb
+++ b/spec/models/version_control/file_collection_spec.rb
@@ -75,6 +75,10 @@ RSpec.describe VersionControl::FileCollection, type: :model do
       is_expected.to be_a VersionControl::File
     end
 
+    it 'marks file as persisted' do
+      is_expected.to be_persisted
+    end
+
     it 'ignores case' do
       expect(file_collection.find(file.name.upcase).oid).to eq file.oid
       expect(file_collection.find(file.name.downcase).oid).to eq file.oid
@@ -122,6 +126,11 @@ RSpec.describe VersionControl::FileCollection, type: :model do
           end
         ).to be true
       end
+    end
+
+    it 'marks files as persisted' do
+      create_list :vc_file, 5, collection: file_collection
+      expect(subject.all?(&:persisted?)).to be true
     end
 
     context 'when no commit exists' do

--- a/spec/models/version_control/file_collection_spec.rb
+++ b/spec/models/version_control/file_collection_spec.rb
@@ -7,13 +7,6 @@ RSpec.describe VersionControl::FileCollection, type: :model do
     expect { subject }.not_to raise_error
   end
 
-  describe 'delegations' do
-    it 'delegates #lookup' do
-      expect_any_instance_of(VersionControl::Repository).to receive :lookup
-      subject.send :lookup, 'string'
-    end
-  end
-
   describe '.new(repository)' do
     context 'when repository is nil' do
       subject(:file_collection) { build :vc_file_collection, repository: nil }
@@ -33,73 +26,27 @@ RSpec.describe VersionControl::FileCollection, type: :model do
   end
 
   describe '#create' do
-    subject(:method)  { file_collection.create name, content, message, author }
-    let(:author)      { build(:user) }
-    let(:content)     { Faker::Lorem.paragraphs.join('\n\n') }
-    let(:name)        { Faker::File.file_name('', nil, nil, '') }
-    let(:message)     { Faker::Simpsons.quote }
-    let(:repository)  { file_collection.instance_variable_get(:@repository) }
-
-    it { is_expected.to be true }
-
-    it 'writes the blob to the repository' do
-      expect_any_instance_of(VersionControl::Repository)
-        .to receive(:write)
-        .with(content, :blob)
-        .and_call_original
-      method
+    subject(:method)      { file_collection.create arguments }
+    let(:file_collection) { build :vc_file_collection }
+    let(:arguments) do
+      {
+        name: 'file1',
+        content: 'Content of the new file',
+        revision_summary: 'Create new file: file1',
+        revision_author: build_stubbed(:user)
+      }
     end
 
-    it 'drop previously staged files (reset to last commit)' do
-      # stage three files
-      3.times.with_index do |i|
-        blob_oid = repository.write("file content #{i}", :blob)
-        repository.index.add path: "File#{i}", oid: blob_oid, mode: 0o100644
-      end
-
-      # run method
-      method
-
-      # Confirm that previous staged files are not included in commit
-      tree = repository.branches['master'].target.tree
-      expect(tree.count).to eq 1
-      tree.each do |file|
-        expect(file[:name]).not_to match(/File[123]/)
-      end
-    end
-
-    it 'stages the new file' do
-      method
-      # Get the tree of the last commit
-      tree = repository.branches['master'].target.tree
-
-      # Confirm that file path is in tree
-      expect(tree.any? { |file| file[:name] == name }).to be true
-
-      # Confirm that blob content is what we submitted
-      blob_oid = tree.find { |f| f[:name] == name }[:oid]
-      expect(repository.lookup(blob_oid).content).to eq content
-    end
-
-    it 'calls commit on the repository' do
-      expect_any_instance_of(VersionControl::Repository)
-        .to receive(:commit)
-        .with message, author
+    it 'calls .create on VersionControl::File' do
+      expect(VersionControl::File)
+        .to receive(:create).with arguments.merge(collection: file_collection)
       method
     end
 
     it 'calls reload! on itself' do
-      expect(file_collection).to receive :reload!
+      allow(VersionControl::File).to receive(:create)
+      expect(file_collection).to receive(:reload!)
       method
-    end
-
-    context 'when commit fails' do
-      before do
-        allow_any_instance_of(VersionControl::Repository)
-          .to receive(:commit)
-          .and_return false
-      end
-      it { is_expected.to be false }
     end
   end
 
@@ -154,14 +101,17 @@ RSpec.describe VersionControl::FileCollection, type: :model do
     end
 
     it 'initializes VersionControl::File objects' do
-      subject.create 'name', 'content', 'message', author
+      create :vc_file, collection: file_collection
       expect(subject.entries.first).to be_a VersionControl::File
     end
 
     it 'consists of files from last commit on master branch' do
       # Create 3 files
       3.times.with_index do |i|
-        subject.create "file#{i}", "content#{i}", 'message', author
+        create(:vc_file,
+               name: "file#{i}",
+               content: "content#{i}",
+               collection: file_collection)
       end
 
       # Confirm three files in collection

--- a/spec/models/version_control/file_collection_spec.rb
+++ b/spec/models/version_control/file_collection_spec.rb
@@ -51,11 +51,12 @@ RSpec.describe VersionControl::FileCollection, type: :model do
   end
 
   describe '#exists?' do
-    subject(:method)  { file_collection.exists? name }
+    subject(:method)  { file_collection.reload!.exists? name }
     let(:name)        { file.name }
     let!(:file)       { create :vc_file, collection: file_collection }
     it                { is_expected.to be true }
     it 'ignores case' do
+      file_collection.reload!
       expect(file_collection).to exist file.name.upcase
       expect(file_collection).to exist file.name.downcase
     end
@@ -67,7 +68,7 @@ RSpec.describe VersionControl::FileCollection, type: :model do
   end
 
   describe '#find' do
-    subject(:method)  { file_collection.find name }
+    subject(:method)  { file_collection.reload!.find name }
     let(:name)        { file.name }
     let!(:file)       { create :vc_file, collection: file_collection }
 
@@ -80,6 +81,7 @@ RSpec.describe VersionControl::FileCollection, type: :model do
     end
 
     it 'ignores case' do
+      file_collection.reload!
       expect(file_collection.find(file.name.upcase).oid).to eq file.oid
       expect(file_collection.find(file.name.downcase).oid).to eq file.oid
     end
@@ -106,7 +108,7 @@ RSpec.describe VersionControl::FileCollection, type: :model do
 
     it 'initializes VersionControl::File objects' do
       create :vc_file, collection: file_collection
-      expect(subject.entries.first).to be_a VersionControl::File
+      expect(subject.reload!.entries.first).to be_a VersionControl::File
     end
 
     it 'consists of files from last commit on master branch' do
@@ -121,7 +123,7 @@ RSpec.describe VersionControl::FileCollection, type: :model do
       # Confirm three files in collection
       3.times.with_index do |i|
         expect(
-          subject.any? do |file|
+          subject.reload!.any? do |file|
             file.name == "file#{i}" && file.content == "content#{i}"
           end
         ).to be true

--- a/spec/models/version_control/file_spec.rb
+++ b/spec/models/version_control/file_spec.rb
@@ -385,6 +385,44 @@ RSpec.describe VersionControl::File, type: :model do
     end
   end
 
+  describe '#update' do
+    subject(:method)  { file.update(params) }
+    let(:file)        { create :vc_file }
+    let(:collection)  { file.collection.reload! }
+    let(:params) do
+      {
+        name: 'file1',
+        content: 'My new file! :)',
+        revision_summary: 'Create file1',
+        revision_author: build_stubbed(:user)
+      }
+    end
+
+    it 'sets content to new value' do
+      method
+      expect(collection.first.content).to eq params[:content]
+    end
+
+    it 'sets name to new value' do
+      method
+      expect(collection.first.name).to eq params[:name]
+    end
+
+    it 'calls #save on VersionControl::File instance' do
+      expect(file).to receive(:save).and_call_original
+      method
+    end
+
+    context 'when params are not passed' do
+      subject(:method) { file.update }
+
+      it 'calls #save on VersionControl::File instance' do
+        expect(file).to receive(:save).and_call_original
+        method
+      end
+    end
+  end
+
   describe '#write_content_to_repository' do
     subject(:method)  { file.write_content_to_repository }
     let(:file)        { build :vc_file }

--- a/spec/models/version_control/file_spec.rb
+++ b/spec/models/version_control/file_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe VersionControl::File, type: :model do
     end
 
     it { is_expected.to be_a VersionControl::File }
+    it { is_expected.to be_persisted }
 
     it 'drop previously staged files (reset to last commit)' do
       # make sure we have a previous commit
@@ -122,6 +123,16 @@ RSpec.describe VersionControl::File, type: :model do
     subject(:method)  { file.content }
     let(:file)        { create :vc_file }
     it                { is_expected.to eq file.content }
+  end
+
+  describe '#persisted?' do
+    subject(:file) { VersionControl::File.new }
+    it { is_expected.not_to be_persisted }
+
+    context 'when persisted is set true on initialization' do
+      subject(:file) { VersionControl::File.new persisted: true }
+      it { is_expected.to be_persisted }
+    end
   end
 
   describe '#write_content_to_repository' do

--- a/spec/models/version_control/file_spec.rb
+++ b/spec/models/version_control/file_spec.rb
@@ -4,12 +4,136 @@ RSpec.describe VersionControl::File, type: :model do
   subject(:file) { build :vc_file }
 
   it 'has a valid factory' do
-    expect { subject }.not_to raise_error
+    is_expected.to be_valid
+  end
+
+  describe 'delegations' do
+    it 'delegates #repository' do
+      expect_any_instance_of(VersionControl::FileCollection)
+        .to receive :repository
+      subject.send :repository
+    end
+  end
+
+  describe 'validations' do
+    context 'on :create' do
+      it { is_expected.to validate_presence_of(:revision_author).on(:create) }
+      it { is_expected.to validate_presence_of(:revision_summary).on(:create) }
+      context 'when validating name' do
+        it { is_expected.to validate_presence_of(:name).on(:create) }
+
+        it 'identical names are invalid' do
+          existing_file = create :vc_file, collection: file.collection
+          file.name = existing_file.name
+          expect(file).to be_invalid(:create)
+        end
+
+        it 'different cases of the same name are invalid' do
+          existing_file = create :vc_file, collection: file.collection
+          file.name = existing_file.name.upcase
+          expect(file).to be_invalid(:create)
+        end
+
+        it 'identical names in different repositories are valid' do
+          existing_file = create :vc_file
+          file.name = existing_file.name
+          expect(file).to be_valid(:create)
+        end
+
+        it 'forward-slash is invalid' do
+          file.name = 'my/new/name'
+          expect(file).to be_invalid(:create)
+        end
+      end
+    end
+  end
+
+  describe '.create' do
+    subject(:method)      { VersionControl::File.create params }
+    let(:repository)      { build :vc_repository }
+    let(:file_collection) { build :vc_file_collection, repository: repository }
+    let(:params) do
+      {
+        name: 'file1',
+        content: 'My new file! :)',
+        collection: file_collection,
+        revision_summary: 'Create file1',
+        revision_author: build_stubbed(:user)
+      }
+    end
+
+    it { is_expected.to be_a VersionControl::File }
+
+    it 'drop previously staged files (reset to last commit)' do
+      # make sure we have a previous commit
+      repository.commit 'initial commit', build_stubbed(:user)
+
+      # stage three files
+      3.times.with_index do |i|
+        blob_oid = repository.write("file content #{i}", :blob)
+        repository.index.add path: "File#{i}", oid: blob_oid, mode: 0o100644
+      end
+
+      # run method
+      method
+
+      # Confirm that previous staged files are not included in commit
+      tree = repository.branches['master'].target.tree
+      expect(tree.count).to eq 1
+      tree.each do |file|
+        expect(file[:name]).not_to match(/File[123]/)
+      end
+    end
+
+    it 'adds a new file to version control' do
+      expect { method }.to(
+        change { file_collection.reload!.count }.from(0).to(1)
+      )
+    end
+
+    it 'saves the name' do
+      method
+      expect(file_collection.reload!).to exist params[:name]
+    end
+
+    it 'saves the content' do
+      method
+      expect(file_collection.reload!.find(params[:name]).content)
+        .to eq params[:content]
+    end
+
+    it 'resets revision author and revision summary' do
+      file = method
+      expect(file.revision_author).to be nil
+      expect(file.revision_summary).to be nil
+    end
+
+    context 'when file is invalid' do
+      before do
+        allow_any_instance_of(VersionControl::File)
+          .to receive(:valid?)
+          .and_return false
+      end
+      it { is_expected.to be false }
+    end
   end
 
   describe '#content' do
     subject(:method)  { file.content }
     let(:file)        { create :vc_file }
     it                { is_expected.to eq file.content }
+  end
+
+  describe '#write_content_to_repository' do
+    subject(:method)  { file.write_content_to_repository }
+    let(:file)        { build :vc_file }
+
+    it 'writes the blob to the repository' do
+      expect_any_instance_of(VersionControl::Repository)
+        .to receive(:write)
+        .with(file.content, :blob)
+        .and_call_original
+      method
+    end
   end
 end

--- a/spec/models/version_control/repository_spec.rb
+++ b/spec/models/version_control/repository_spec.rb
@@ -169,10 +169,7 @@ RSpec.describe VersionControl::Repository, type: :model do
     let(:file_collection) { VersionControl::FileCollection.new repository }
     before do
       # create a commit
-      file_collection.create 'README.md',
-                             'This is my readme',
-                             'commit msg',
-                             author
+      create :vc_file, collection: file_collection
     end
 
     it 'sets stage to last commit on master' do


### PR DESCRIPTION
Implement ActiveRecord-like methods to make VersionControl::File behave as if it
was a tableless ActiveRecord object. The implemented behaviors are:
- Validations
- Dirty tracking (tracking changes)
- Persistence checking
- Creating a record
- Updating a record
- Destroying a record