### PR TITLE
Fix: VersionControl::File#content is nil for new instances

### DIFF
--- a/app/models/version_control/file.rb
+++ b/app/models/version_control/file.rb
@@ -86,7 +86,7 @@ module VersionControl
 
     # Return the file's content
     def content
-      @content ||= repository.lookup(oid).content
+      @content ||= (repository.lookup(oid).content if oid)
     end
 
     # Destroy the file

--- a/spec/models/version_control/file_spec.rb
+++ b/spec/models/version_control/file_spec.rb
@@ -123,6 +123,14 @@ RSpec.describe VersionControl::File, type: :model do
     subject(:method)  { file.content }
     let(:file)        { create :vc_file }
     it                { is_expected.to eq file.content }
+
+    context 'when file content is nil and oid is nil' do
+      before do
+        file.instance_variable_set :@content, nil
+        file.instance_variable_set :@oid, nil
+      end
+      it { is_expected.to eq nil }
+    end
   end
 
   describe '#destroy' do


### PR DESCRIPTION
When calling VersionControl::File#content on instances where @content is
nil and @oid is nil, an error would occur. This was due to the fact that
Rugged::Repository#lookup raises an error if a non-string parameter is
passed. This fixes the problem by only calling lookup if
VersionControl::File#oid is not nil.