### PR TITLE
Fix: Enable invalid styling on inherited input

### DIFF
--- a/app/assets/stylesheets/shared/forms.scss
+++ b/app/assets/stylesheets/shared/forms.scss
@@ -12,13 +12,16 @@ input[type='text'] {
   // Input elements that inherit styling from their parent
   &.inherit {
     // scss-lint:disable ImportantRule
-    border-color: currentColor !important;
     box-shadow: none !important;
     font-size: inherit;
     height: auto;
     line-height: inherit;
     margin: 0;
     padding: 0;
+
+    &:not(.invalid) {
+      border-color: currentColor !important;
+    }
   }
 }
 // scss-lint:enable QualifyingElement


### PR DESCRIPTION
Input elements that inherit styling from its parent container (for
example, input elements that imitate the look of a heading) do not
override border color when they have class 'invalid'. This allows them
to match other invalid input elements which are also red underlined.