### PR TITLE
Fix vc_file factory: Line breaks in content

### DIFF
--- a/spec/factories/version_control/file.rb
+++ b/spec/factories/version_control/file.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :vc_file, class: VersionControl::File do
     name              { Faker::File.unique.file_name('', nil, nil, '') }
     collection        { build :vc_file_collection }
-    content           { Faker::Lorem.paragraphs.join('\n\n') }
+    content           { Faker::Lorem.paragraphs.join("\n\n") }
     oid               { Faker::Crypto.sha1 }
     revision_author   { build :user }
     revision_summary  { Faker::Simpsons.quote }


### PR DESCRIPTION
The paragraphs generated by Faker must be joined by "\n\n" rather than '\n\n'. The line break character \n is escaped if it is written with single quotes.