### PR TITLE
Join Upshift page: Remove border top from card

### DIFF
--- a/app/assets/stylesheets/shared/all.scss
+++ b/app/assets/stylesheets/shared/all.scss
@@ -1,6 +1,7 @@
 // CSS styles meant to be shared across the entire application
 
 @import 'banner';
+@import 'border';
 @import 'buttons';
 @import 'cards';
 @import 'chips';

--- a/app/assets/stylesheets/shared/border.scss
+++ b/app/assets/stylesheets/shared/border.scss
@@ -1,0 +1,7 @@
+// Remove border for specific direction
+@each $direction in 'top', 'right', 'left', 'bottom' {
+  .no-border-#{$direction} {
+    // scss-lint:disable ImportantRule
+    border-#{$direction}: 0 !important;
+  }
+}

--- a/app/views/devise/registrations/_card.slim
+++ b/app/views/devise/registrations/_card.slim
@@ -1,6 +1,6 @@
 .card.no-margin-bottom
   .card-content
-    span.card-title
+    span.card-title.no-border-top
       ' You will
       svg.red-text> style="width:24px;height:24px" viewBox="0 0 24 24"
         path fill="currentColor" d="M12,21.35L10.55,20.03C5.4,15.36 2,12.27 2,8.5C2,5.41 4.42,3 7.5,3C9.24,3 10.91,3.81 12,5.08C13.09,3.81 14.76,3 16.5,3C19.58,3 22,5.41 22,8.5C22,12.27 18.6,15.36 13.45,20.03L12,21.35Z"


### PR DESCRIPTION
We added a border top to all card titles when we created cards for each of a user's projects (on the users#show page). However, the card on the registration page is not meant to have a top border.