### PR TITLE
Fix: Navbar: Set logo size in HTML tag

### DIFF
--- a/app/views/application/_navbar.slim
+++ b/app/views/application/_navbar.slim
@@ -2,7 +2,7 @@ nav.primary-color-darken.primary-color-text
   .container
     .nav-wrapper
       = link_to root_path, class: 'brand-logo' do
-        = image_tag 'logo.svg'
+        = image_tag 'logo.svg', size:'42x42'
         | Upshift One
     ul.right.hide-on-med-and-down
       - navigation_links.each do |link|


### PR DESCRIPTION
When the HTML page is loaded and rendered before the stylesheet is loaded, the logo is sometimes rendered at full page size. Add explicit width and height (42px * 42px) into the HTML tag to avoid this problem.