### PR TITLE
Fix: Projects#show: Remove margin between banner and text

### DIFF
--- a/app/assets/stylesheets/shared/buttons.scss
+++ b/app/assets/stylesheets/shared/buttons.scss
@@ -2,6 +2,8 @@
 
 // Floating action bar
 .action-bar {
+  height: $button-floating-large-size;
+  margin-bottom: - $button-floating-large-size;
   position: relative;
   top: - $button-floating-large-size / 2;
 }


### PR DESCRIPTION
Remove the spacing between the banner and the heading ('Overview').