### PR TITLE
Fix: Prevent chips from overflowing

### DIFF
--- a/app/assets/stylesheets/shared/chips.scss
+++ b/app/assets/stylesheets/shared/chips.scss
@@ -1,5 +1,13 @@
 // Styling for chips
 
+// Truncate chips to single line
+.chip {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 // SVG icon inside a chip
 .chip .icon {
   display: inline-block;


### PR DESCRIPTION
Truncate chips at max-width of 100%.