### PR TITLE
Fix: Avoid foreign key constraint error

### DIFF
--- a/app/models/discussions/base.rb
+++ b/app/models/discussions/base.rb
@@ -14,17 +14,20 @@ module Discussions
     # Associations
     belongs_to :initiator, class_name: 'User'
     belongs_to :project, class_name: 'Project'
+    # Association replies MUST precede initial_reply. If not, the destroy method
+    # will fail as there will be one reply left in the DB.
+    has_many :replies,
+             -> { order(:id).offset(1) },
+             class_name: 'Reply',
+             dependent: :destroy,
+             inverse_of: :discussion,
+             foreign_key: 'discussion_id'
     has_one :initial_reply,
             -> { order(:id).limit(1) },
             class_name: 'Reply',
             dependent: :destroy,
             inverse_of: :discussion,
             foreign_key: 'discussion_id'
-    has_many :replies,
-             -> { order(:id).offset(1) },
-             dependent: :destroy,
-             inverse_of: :discussion,
-             foreign_key: 'discussion_id'
 
     # Attributes
     accepts_nested_attributes_for :initial_reply

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,10 @@ class User < ApplicationRecord
   belongs_to :account
   has_one :handle, as: :profile, dependent: :destroy, inverse_of: :profile
   has_many :projects, as: :owner, dependent: :destroy, inverse_of: :owner
+  has_many :discussions, class_name: 'Discussions::Base',
+                         dependent: :destroy,
+                         foreign_key: :initiator_id,
+                         inverse_of: :initiator
 
   # Attributes
   accepts_nested_attributes_for :handle

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,9 @@ class User < ApplicationRecord
                          dependent: :destroy,
                          foreign_key: :initiator_id,
                          inverse_of: :initiator
+  has_many :replies, dependent: :destroy,
+                     foreign_key: :author_id,
+                     inverse_of: :author
 
   # Attributes
   accepts_nested_attributes_for :handle

--- a/spec/factories/replies.rb
+++ b/spec/factories/replies.rb
@@ -4,6 +4,6 @@ FactoryGirl.define do
   factory :reply do
     content { Faker::Lorem.paragraphs.join("\n\n") }
     association :author, factory: :user
-    discussion { build :discussions_suggestion, initial_reply: Reply.new }
+    association :discussion, factory: :discussions_suggestion
   end
 end

--- a/spec/features/account_spec.rb
+++ b/spec/features/account_spec.rb
@@ -70,6 +70,7 @@ feature 'Account' do
     projects = create_list(:project, 3, owner: account.user)
     create_list(:discussions_suggestion, 3, project: projects.first,
                                             initiator: account.user)
+    create_list(:reply, 3, author: account.user)
     # sign in
     sign_in_as account
     # and I am on the homepage

--- a/spec/models/shared_examples/being_a_discussion.rb
+++ b/spec/models/shared_examples/being_a_discussion.rb
@@ -85,6 +85,15 @@ RSpec.shared_examples 'being a discussion' do |discussion_type|
     it { is_expected.to validate_presence_of(:initial_reply) }
   end
 
+  describe '#destroy' do
+    # verify that no ActiveRecord::InvalidForeignKey error is raised
+    context 'when replies exist' do
+      before { subject.save }
+      before { create_list(:reply, 3, discussion: subject) }
+      it { expect { subject.destroy }.not_to raise_error }
+    end
+  end
+
   describe '#to_param' do
     before  { subject.save }
     it      { expect(subject.to_param).to eq 1 }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe User, type: :model do
     it do
       is_expected.to have_many(:projects).dependent(:destroy).inverse_of :owner
     end
+    it do
+      is_expected.to(
+        have_many(:discussions)
+          .class_name('Discussions::Base')
+          .dependent(:destroy)
+          .with_foreign_key(:initiator_id)
+          .inverse_of(:initiator)
+      )
+    end
   end
 
   describe 'attributes' do
@@ -37,6 +46,15 @@ RSpec.describe User, type: :model do
     end
     it { is_expected.to validate_presence_of(:handle).on(:create) }
     it { is_expected.to validate_presence_of(:name) }
+  end
+
+  describe '#destroy' do
+    # verify that no ActiveRecord::InvalidForeignKey error is raised
+    context 'when discussions exist' do
+      let(:user) { create(:user) }
+      before { create_list(:discussions_suggestion, 3, initiator: user) }
+      it { expect { subject.destroy }.not_to raise_error }
+    end
   end
 
   describe '#to_param' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,6 +33,14 @@ RSpec.describe User, type: :model do
           .inverse_of(:initiator)
       )
     end
+    it do
+      is_expected.to(
+        have_many(:replies)
+          .dependent(:destroy)
+          .with_foreign_key(:author_id)
+          .inverse_of(:author)
+      )
+    end
   end
 
   describe 'attributes' do
@@ -53,6 +61,11 @@ RSpec.describe User, type: :model do
     context 'when discussions exist' do
       let(:user) { create(:user) }
       before { create_list(:discussions_suggestion, 3, initiator: user) }
+      it { expect { subject.destroy }.not_to raise_error }
+    end
+    context 'when replies exist' do
+      let(:user) { create(:user) }
+      before { create_list(:reply, 3, author: user) }
       it { expect { subject.destroy }.not_to raise_error }
     end
   end


### PR DESCRIPTION
When destroying user, ...
- destroy initiated discussions
- destroy authored replies

When destroying discussion, ...
- destroy associated replies