### PR TITLE
Hotfix 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.6.1 (November 21, 2017)
+
+- Fix: Support absolute file paths for Google Drive credentials file
+
 ## v0.6 (November 21, 2017)
 
 **New Features**:

--- a/app/models/google_drive.rb
+++ b/app/models/google_drive.rb
@@ -53,7 +53,7 @@ class GoogleDrive
     # FileTokenStore stores the access token in a file
     def token_store
       Google::Auth::Stores::FileTokenStore.new(
-        file: File.join(Dir.home, ENV['GOOGLE_DRIVE_CREDENTIALS_PATH'])
+        file: File.join(ENV['GOOGLE_DRIVE_CREDENTIALS_PATH'])
       )
     end
   end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -12,7 +12,7 @@
 
 GOOGLE_DRIVE_CLIENT_ID: <client id from credentials.json>
 GOOGLE_DRIVE_CLIENT_SECRET: <client secret from credentials.json>
-GOOGLE_DRIVE_CREDENTIALS_PATH: '.credentials/google.yaml'
+GOOGLE_DRIVE_CREDENTIALS_PATH: '/home/user/credentials/google.yaml'
 
 production:
   DEPLOY_USER: <username of user for deployment>
@@ -23,7 +23,3 @@ production:
 
 test:
   MOCK_GOOGLE_DRIVE_REQUESTS: 'false' # set to 'true' to mock requests
-  # You should have a separate path for test credentials (even though the
-  # contained credentials can be identical) because otherwise your tests and
-  # development environment will kick each other out
-  GOOGLE_DRIVE_CREDENTIALS_PATH: '.credentials/google-test.yaml'


### PR DESCRIPTION
- Fix: Support absolute path for Google credentials file

On our production environment, we need to refer to the credentials file not from our user's home directory but from an absolute path. This commit switches support from relative to absolute paths.