### PR TITLE
Fix: Drop DB table 'notification_channels'

### DIFF
--- a/db/migrate/20180108180921_drop_notification_channels.rb
+++ b/db/migrate/20180108180921_drop_notification_channels.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Drop the notification_channels table
+class DropNotificationChannels < ActiveRecord::Migration[5.1]
+  def up
+    drop_table 'notification_channels'
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def down
+    create_table 'notification_channels' do |t|
+      t.bigint 'project_id', null: false
+      t.bigint 'file_item_id', null: false
+      t.integer 'status', default: 0, null: false
+      t.datetime 'expires_at'
+      t.datetime 'created_at', null: false
+      t.datetime 'updated_at', null: false
+      t.index ['file_item_id'],
+              name: 'index_notification_channels_on_file_item_id'
+      t.index ['project_id'], name: 'index_notification_channels_on_project_id'
+      t.index ['status'], name: 'index_notification_channels_on_status'
+    end
+  end
+  # rubocop:enable Metrics/MethodLength
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180108071756) do
+ActiveRecord::Schema.define(version: 20180108180921) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,18 +40,6 @@ ActiveRecord::Schema.define(version: 20180108071756) do
     t.string "delayed_reference_type"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
     t.index ["queue"], name: "index_delayed_jobs_on_queue"
-  end
-
-  create_table "notification_channels", force: :cascade do |t|
-    t.bigint "project_id", null: false
-    t.bigint "file_item_id", null: false
-    t.integer "status", default: 0, null: false
-    t.datetime "expires_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["file_item_id"], name: "index_notification_channels_on_file_item_id"
-    t.index ["project_id"], name: "index_notification_channels_on_project_id"
-    t.index ["status"], name: "index_notification_channels_on_status"
   end
 
   create_table "profiles", force: :cascade do |t|


### PR DESCRIPTION
The table has never been used (we never had a model NotificationChannel). It was added in c872e6aad39671869ca8c9fd11ba8f50ae8994e3. It probably sneaked in when switching back and forth between different Git branches.