### PR TITLE
Show list of file changes when user creates new revision

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -6,6 +6,9 @@ guard :rspec, cmd: 'bundle exec rspec' do
   watch('config/routes.rb')                           { 'spec/routing' }
   watch('app/controllers/application_controller.rb')  { 'spec/controllers' }
   watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^app/models/(.+)\.rb$}) do |m|
+    "spec/integrations/#{m[1]}_spec.rb"
+  end
   watch(%r{^app/(.+)\.rb$}) do |m|
     "spec/#{m[1]}_spec.rb"
   end

--- a/app/assets/stylesheets/controllers/all.scss
+++ b/app/assets/stylesheets/controllers/all.scss
@@ -3,4 +3,5 @@
 @import 'errors';
 @import 'folders';
 @import 'profiles';
+@import 'revisions';
 @import 'static';

--- a/app/assets/stylesheets/controllers/revisions.scss
+++ b/app/assets/stylesheets/controllers/revisions.scss
@@ -1,0 +1,56 @@
+// Styling for ProfilesController
+
+.c-revisions {
+
+  h3 {
+    position: relative;
+    z-index: 1;
+
+    // Horizontal line/divider behind heading
+    // Adapted from: https://codepen.io/ericrasch/pen/Irlpm
+    &::before {
+      border-top: 1px solid $divider-color;
+      bottom: 0;
+      content: '';
+      left: 0;
+      // positioning must be absolute here, and relative positioning must be
+      // applied to the parent
+      position: absolute;
+      right: 0;
+      top: 50%;
+      width: 100%;
+      z-index: -1;
+    }
+
+    span {
+      // to hide the lines from behind the text, you have to set the background
+      // color the same as the container
+      background: $background-color;
+      padding-right: 25px;
+    }
+  }
+
+  .file {
+    // scss-lint:disable NestingDepth
+
+    .file-icon {
+      float: left;
+      height: 30px;
+      width: 30px;
+    }
+
+    .file-name {
+      display: block;
+      line-height: 20px;
+      padding: 5px 0 5px 35px;
+    }
+
+    a {
+      color: inherit;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/shared/document.scss
+++ b/app/assets/stylesheets/shared/document.scss
@@ -8,7 +8,7 @@ html {
 
 body {
   // Body color should be a slight gray
-  background-color: color('gray', 'lighten-4');
+  background-color: $background-color;
 
   // Flex body so that we can have a sticky footer
   display: flex;

--- a/app/assets/stylesheets/shared/spacing.scss
+++ b/app/assets/stylesheets/shared/spacing.scss
@@ -1,7 +1,12 @@
 // Styles for all types of spacings, paddings, and margins
 
 // Add a set amount of vertical spacing between elements
-// Usage: div.spacing with h16, h32, ..., h64, h128
+// Usage: div.spacing with v16, v32, ..., v64, v128
+.spacing.v1 {
+  display: block;
+  height: 1px;
+}
+
 @each $factor in 1, 2, 3, 4, 8 {
   div.spacing.v#{$factor * $base-unit} {
     display: block;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,5 +1,11 @@
 // Variable declarations go here
 
+// The application's background color
+$background-color: color('grey', 'lighten-4');
+
+// The color of dividers
+$divider-color: color('grey', 'lighten-2');
+
 // The basic unit of Material Design
 $base-unit: 16px;
 

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -19,7 +19,8 @@ class RevisionsController < ApplicationController
   def new; end
 
   def create
-    if @revision.commit(revision_params[:summary], revision_author)
+    if @revision.commit(revision_params[:title], revision_params[:summary],
+                        revision_author)
       redirect_with_success_to(
         profile_project_root_folder_path(@project.owner, @project)
       )
@@ -74,7 +75,7 @@ class RevisionsController < ApplicationController
   end
 
   def revision_params
-    params.require(:revision).permit(:summary, :tree_id)
+    params.require(:revision).permit(:title, :summary, :tree_id)
   end
 
   # TODO@refactor: This should not be the controller's responsibility. Ideally,

--- a/app/helpers/file_diff_helper.rb
+++ b/app/helpers/file_diff_helper.rb
@@ -15,10 +15,10 @@ module FileDiffHelper
   end
 
   # Return the HTML class for the change that has been made to the file
-  def html_class_for_file_diff(file_diff)
-    return 'unchanged' unless file_diff.changed?
+  def html_class_for_file_diff_changes(file_diff_changes)
+    return 'unchanged' if file_diff_changes.empty?
 
-    "changed #{file_diff.changes.join(' ')}"
+    "changed #{file_diff_changes.join(' ')}"
   end
 
   # Get the SVG path for the file change
@@ -49,8 +49,8 @@ module FileDiffHelper
   end
 
   # Return the text color class for the change that has been made to the file
-  def text_color_for_file_diff(file_diff)
-    scheme = color_for_file_diff_change(file_diff.changes.first)&.split(' ')
+  def text_color_for_file_diff_change(file_diff_change)
+    scheme = color_for_file_diff_change(file_diff_change)&.split(' ')
     return nil if scheme.nil?
 
     "#{scheme.first}-text text-#{scheme.last}"

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -37,19 +37,18 @@ module FileHelper
   # Wrap block into a link_to the file.
   # If the file is a directory, wraps into an internal link to that directory.
   # If the file is not a directory, wraps into an external link to Drive.
-  def link_to_file(file, project, &block)
+  def link_to_file(file, project, options = {}, &block)
     # internal link to that folder
     if file.directory?
-      link_to profile_project_folder_path(project.owner, project, file.id) do
-        capture(&block)
-      end
+      path = profile_project_folder_path(project.owner, project, file.id)
 
     # external link to the original file on Google Drive
     else
-      link_to external_link_for_file(file), target: '_blank' do
-        capture(&block)
-      end
+      path = external_link_for_file(file)
+      options.reverse_merge! target: '_blank'
     end
+
+    link_to(path, options) { capture(&block) }
   end
 
   # Sort files according to sort order
@@ -89,4 +88,6 @@ module FileHelper
     else                                                 :other
     end
   end
+
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/app/models/version_control/file.rb
+++ b/app/models/version_control/file.rb
@@ -26,6 +26,18 @@ module VersionControl
       mime_type == 'application/vnd.google-apps.folder'
     end
 
+    # Generate the file's metadata path from its file path and whether it is a
+    # folder. Adds /.self to any folder
+    def self.file_path_to_metadata_path(file_path, is_folder)
+      is_folder ? "#{file_path}/.self" : file_path
+    end
+
+    # Generate the file path from a file's metadata path
+    # Essentially, just remove /.self from any paths that have that ending.
+    def self.metadata_path_to_file_path(metadata_path)
+      metadata_path.chomp '/.self'
+    end
+
     # Initialize the instance
     def initialize(file_collection, params)
       @file_collection  = file_collection
@@ -34,7 +46,7 @@ module VersionControl
       @parent_id        = params[:parent_id]
       @mime_type        = params[:mime_type]
       @version          = params[:version]
-      @modified_time    = params[:modified_time]&.utc
+      @modified_time    = params[:modified_time]
       @path             = params[:path]
       @git_oid          = params[:git_oid]
     end
@@ -49,6 +61,12 @@ module VersionControl
     # Return true if file is a directory, false otherwise
     def directory?
       self.class.directory_type?(mime_type)
+    end
+
+    # The path to the file's metadata file
+    def metadata_path
+      return nil unless path.present?
+      self.class.file_path_to_metadata_path(path, directory?)
     end
   end
 end

--- a/app/models/version_control/file_collections/staged.rb
+++ b/app/models/version_control/file_collections/staged.rb
@@ -128,7 +128,9 @@ module VersionControl
       # Load the YAML metadata from the provided path
       def load_metadata(path)
         lock do
-          YAML.load_file(metadata_path_from_file_path(path))&.symbolize_keys
+          YAML.load_file(
+            File.file_path_to_metadata_path(path, ::File.directory?(path))
+          )&.symbolize_keys
         end
       end
 
@@ -146,13 +148,6 @@ module VersionControl
             is_root: (id == root_id)
             # TODO: Pass path variable
           )
-        end
-      end
-
-      # Generate the metadata path based on the file path
-      def metadata_path_from_file_path(path)
-        lock do
-          ::File.directory?(path) ? "#{path}/.self" : path
         end
       end
 

--- a/app/models/version_control/files/staged.rb
+++ b/app/models/version_control/files/staged.rb
@@ -138,7 +138,6 @@ module VersionControl
       # Set new attribute values from params hash
       def update_attributes_from_hash(params)
         @name           = params[:name]          if params.key? :name
-        @mime_type      = params[:mime_type]     if params.key? :mime_type
         @version        = params[:version]       if params.key? :version
         @modified_time  = params[:modified_time] if params.key? :modified_time
       end

--- a/app/models/version_control/files/staged.rb
+++ b/app/models/version_control/files/staged.rb
@@ -111,11 +111,6 @@ module VersionControl
           modified_time: modified_time }
       end
 
-      # The path to the file's metadata
-      def metadata_path
-        path
-      end
-
       # Move the file to a new location specified by new_parent_id
       # If new_parent_id is nil, does not exist, or is outside of the
       # repository, the file is destroyed.

--- a/app/models/version_control/files/staged/folder.rb
+++ b/app/models/version_control/files/staged/folder.rb
@@ -33,12 +33,6 @@ module VersionControl
             write_metadata
           end
         end
-
-        # The path to the folder's metadata file
-        def metadata_path
-          return nil unless path.present?
-          "#{path}/.self"
-        end
       end
     end
   end

--- a/app/models/version_control/revision_diff.rb
+++ b/app/models/version_control/revision_diff.rb
@@ -13,6 +13,17 @@ module VersionControl
       @differentiator = differentiator
     end
 
+    # Return an array of FileDiffs consisting of the files that have changed
+    # from differentiator to base
+    def changed_files_as_diffs
+      files_to_diffs(
+        _files_of_blobs_added_to_base,
+        _files_of_blobs_deleted_from_differentiator,
+        _files_of_blobs_added_to_base.map(&:id) |
+        _files_of_blobs_deleted_from_differentiator.map(&:id)
+      )
+    end
+
     # Generate a FileDiff between base and differentiator revision for the file
     # with the provided ID.
     # Raise error if file is found in neither base nor differentiator revision.
@@ -54,6 +65,76 @@ module VersionControl
       else
         yield
       end
+    end
+
+    def repository
+      base&.repository || differentiator&.repository
+    end
+
+    private
+
+    delegate :rugged_repository, to: :repository
+    delegate :tree, to: :base, prefix: true, allow_nil: true
+    delegate :tree, to: :differentiator, prefix: true, allow_nil: true
+
+    # Return the files of the blob objects that were added to base
+    def _files_of_blobs_added_to_base
+      @_files_of_blobs_added_to_base ||=
+        base.files.find_by_path(
+          _paths_from_rugged_deltas_for(:added_blobs)
+        )
+    end
+
+    # Return the files of the blob objects that were deleted from differentiator
+    def _files_of_blobs_deleted_from_differentiator
+      return [] if differentiator.nil?
+
+      @_files_of_blobs_deleted_from_differentiator ||=
+        differentiator.files.find_by_path(
+          _paths_from_rugged_deltas_for(:deleted_blobs)
+        )
+    end
+
+    # Filter an array of delta file hashes to remove files that should not be in
+    # there: empty objects, root, commit metadata, ..
+    # REVIEW@beta: We should get rid of root folders in our repositories
+    #              (we will only commit descendants) and we should also
+    #              eliminate all metadata in commits by then.
+    def _filter_delta_file_hashes!(file_hashes)
+      # Drop objects that are empty (only 0s)
+      file_hashes.reject! { |hash| hash[:oid].match?(/^0+$/) }
+
+      # Drop commit meta information files (dot-files with top-level path)
+      file_hashes.reject! { |hash| hash[:path].start_with? '.' }
+
+      # Drop the metadata file for the root folder, if present
+      file_hashes.reject! { |hash| hash[:path].split('/')[1].start_with? '.' }
+    end
+
+    # Extract and return paths of blobs for :new_file or :old_file
+    def _paths_from_rugged_deltas_for(type_of_blobs)
+      # Collect the correct type of delta file hash (new_file vs old_file)
+      file_hash_key = (type_of_blobs == :added_blobs ? :new_file : :old_file)
+      file_hashes = _rugged_deltas.map { |delta| delta.send(file_hash_key) }
+
+      # Filter file hashes
+      _filter_delta_file_hashes!(file_hashes)
+
+      # Keep only paths
+      paths = file_hashes.map { |hash| hash[:path] }
+      # Convert metadata paths to file paths
+      paths.map { |path| File.metadata_path_to_file_path path }
+    end
+
+    # Return the array of Rugged::Diff::Deltas by diffing differentiator tree
+    # to base tree
+    def _rugged_deltas
+      @_rugged_deltas ||=
+        Rugged::Tree.diff(
+          rugged_repository,
+          differentiator_tree,
+          base_tree
+        ).deltas
     end
   end
 end

--- a/app/models/version_control/revision_diff.rb
+++ b/app/models/version_control/revision_diff.rb
@@ -8,6 +8,10 @@ module VersionControl
     # Initialize an instance of RevisionDiff given two revisions.
     # The base should be the more current revision, the differentiator the less
     # current one.
+    # TODO: Should probably swap the order (it makes more sense to say:
+    #       "generate the change from revision B to revision A" than to say
+    #       "generate the change to revision A from revision B"
+    #       Maybe call the arguments from_revision, to_revision
     def initialize(base, differentiator)
       @base           = base
       @differentiator = differentiator
@@ -123,7 +127,7 @@ module VersionControl
       # Keep only paths
       paths = file_hashes.map { |hash| hash[:path] }
       # Convert metadata paths to file paths
-      paths.map { |path| File.metadata_path_to_file_path path }
+      paths.map { |path| VersionControl::File.metadata_path_to_file_path path }
     end
 
     # Return the array of Rugged::Diff::Deltas by diffing differentiator tree

--- a/app/models/version_control/revisions/drafted.rb
+++ b/app/models/version_control/revisions/drafted.rb
@@ -34,6 +34,11 @@ module VersionControl
         end
       end
 
+      # A file collection for the files in this revision
+      def files
+        @files ||= FileCollections::Committed.new(self)
+      end
+
       # Return the tree for this revision draft
       def tree
         return nil unless @tree_id.present?

--- a/app/models/version_control/revisions/drafted.rb
+++ b/app/models/version_control/revisions/drafted.rb
@@ -6,11 +6,11 @@ module VersionControl
     class Drafted < Revision
       include ActiveModel::Validations
 
-      attr_reader :summary, :tree_id
+      attr_reader :title, :summary, :tree_id
 
       # Validations
-      # Summary must be present
-      validates :summary, presence: true
+      # Title must be present
+      validates :title, presence: true
       validate :last_revision_id_matches_actual_last_revision_id
 
       def initialize(repository, tree_id)
@@ -20,8 +20,9 @@ module VersionControl
 
       # Commit the drafted revision to the repository, making the revision
       # permanent
-      def commit(summary, author)
+      def commit(title, summary, author)
         lock do
+          @title = title
           @summary = summary
           @author = author
 
@@ -54,7 +55,7 @@ module VersionControl
           tree: tree,
           author: author,
           committer: author,
-          message: @summary,
+          message: [@title, @summary].select(&:present?).join("\r\n\r\n"),
           parents: [last_revision_id].compact,
           update_ref: 'HEAD'
         }

--- a/app/views/folders/_ancestors.slim
+++ b/app/views/folders/_ancestors.slim
@@ -1,6 +1,6 @@
 / render the ancestors as breadcrumbs
 
-nav.breadcrumbs.truncate.gray.lighten-2.black-text.z-depth-0
+nav.breadcrumbs.truncate.gray.lighten-3.black-text.z-depth-0
   .container
     .nav-wrapper
       .col.s12

--- a/app/views/folders/_file_diff.slim
+++ b/app/views/folders/_file_diff.slim
@@ -3,7 +3,7 @@
 = link_to_file(file_diff.file_is_or_was, project) do
 
   div.file[class=type_of_file(file_diff.file_is_or_was)
-           class=html_class_for_file_diff(file_diff)]
+           class=html_class_for_file_diff_changes(file_diff.changes)]
 
     div.indicators
       = render partial: 'file_diff_indicator',
@@ -14,6 +14,7 @@
                 size: '100',
                 class: 'img-responsive'
     br
-    span.file-name.truncate[class=html_class_for_file_diff(file_diff)
-                            class=text_color_for_file_diff(file_diff)]
+    span.file-name.truncate[
+      class=text_color_for_file_diff_change(file_diff.changes.first)
+    ]
       = file_diff.name

--- a/app/views/revisions/_file_diff.slim
+++ b/app/views/revisions/_file_diff.slim
@@ -1,0 +1,7 @@
+/ render one entry for every change to the file (i.e. if a document was modified
+/ and moved, it will be shown separately on two consecutive lines)
+= render partial: 'file_diff_change',
+         collection: file_diff.changes,
+         locals: { file_diff: file_diff,
+                   ancestors: ancestors,
+                   project: project }

--- a/app/views/revisions/_file_diff_change.slim
+++ b/app/views/revisions/_file_diff_change.slim
@@ -1,0 +1,13 @@
+div.file[class=type_of_file(file_diff.file_is_or_was)
+         class=file_diff_change]
+
+  = image_tag icon_for_file(file_diff.file_is_or_was),
+             alt: 'File icon',
+             size: '30',
+             class: 'img-responsive file-icon'
+
+  = render partial: 'file_diff_change_text',
+           locals: { file_diff_change: file_diff_change,
+                     file_diff: file_diff,
+                     ancestors: ancestors,
+                     project: project }

--- a/app/views/revisions/_file_diff_change_text.slim
+++ b/app/views/revisions/_file_diff_change_text.slim
@@ -1,0 +1,26 @@
+- added     = (file_diff_change == :added)
+- modified  = (file_diff_change == :modified)
+- moved     = (file_diff_change == :moved)
+- deleted   = (file_diff_change == :deleted)
+
+
+span.file-name[class=text_color_for_file_diff_change(file_diff_change)]
+
+  / print: filename in bold
+  b
+    = link_to_file(file_diff.file_is_or_was, project, target: '_blank') do
+      = file_diff.name
+
+  / print: added/modified/moved/deleted
+  =< file_diff_change
+
+  / print: ancestor path
+  - if moved || added || deleted
+    / Drop root level entry from path and replace with 'Home'
+    - ancestor_path = \
+        ancestors.reverse.map(&:name).drop(1).prepend('Home').join(' > ')
+
+    - if moved || added
+      =< "to #{ancestor_path}"
+    - else
+      =< "from #{ancestor_path}"

--- a/app/views/revisions/new.slim
+++ b/app/views/revisions/new.slim
@@ -4,7 +4,7 @@
     .container
       .row.no-margin-bottom
         .col.s12
-          h2 Review Changes
+          h2 Commit Changes
 
   .container
     - if @revision.errors.any?
@@ -13,7 +13,9 @@
       .row
         .col.s12
           .validation-errors
-            = render partial: "error", collection: @revision.errors.full_messages, as: :error
+            = render partial: "error",
+                     collection: @revision.errors.full_messages,
+                     as: :error
 
     = f.hidden_field :tree_id
 
@@ -24,6 +26,21 @@
           = f.label :summary
 
     .row
-      .col.s12
+      .col.s12.right-align
         button action='submit' class="btn-large primary-color primary-color-text"
           | Commit Changes
+
+    .spacing.v1
+
+    h3: span Review Changes
+    / render preview of file changes
+    - if @file_diffs.none?
+      | There are no changes to review.
+    - else
+      - @file_diffs.each do |diff|
+        = render partial: 'file_diff',
+                 object: diff,
+                 locals: { ancestors: @ancestors_of_file_diffs[diff.id],
+                           project: @project }
+
+    .spacing.v48px

--- a/app/views/revisions/new.slim
+++ b/app/views/revisions/new.slim
@@ -22,8 +22,14 @@
     .row
       .col.s12.l12
         .input-field
-          = f.text_area :summary, rows: 5, placeholder: 'Summarize the changes you have made to files', class: 'inherit materialize-textarea noscript'
-          = f.label :summary
+          = f.text_field :title, placeholder: 'One sentence description of your changes'
+          = f.label :title, 'Title'
+
+    .row
+      .col.s12.l12
+        .input-field
+          = f.text_area :summary, rows: 3, placeholder: 'Summarize the changes you have made to files', class: 'materialize-textarea noscript'
+          = f.label :summary, 'Summary of Changes (optional)'
 
     .row
       .col.s12.right-align

--- a/spec/controllers/revisions_controller_spec.rb
+++ b/spec/controllers/revisions_controller_spec.rb
@@ -5,6 +5,7 @@ require 'controllers/shared_examples/a_repository_locking_action.rb'
 require 'controllers/shared_examples/an_authenticated_action.rb'
 require 'controllers/shared_examples/an_authorized_action.rb'
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
+require 'controllers/shared_examples/successfully_rendering_view.rb'
 
 RSpec.describe RevisionsController, type: :controller do
   let!(:project)        { create :project }
@@ -72,6 +73,15 @@ RSpec.describe RevisionsController, type: :controller do
       expect_any_instance_of(VersionControl::Revisions::Drafted)
         .to receive(:commit)
       run_request
+    end
+
+    context 'when creation fails' do
+      before do
+        allow_any_instance_of(VersionControl::Revisions::Drafted)
+          .to receive(:commit).and_return false
+      end
+
+      it_should_behave_like 'successfully rendering view'
     end
   end
 end

--- a/spec/controllers/revisions_controller_spec.rb
+++ b/spec/controllers/revisions_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RevisionsController, type: :controller do
     let(:add_params) do
       {
         revision: {
-          summary: 'Initial Commit',
+          title: 'Initial Commit',
           tree_id: revision_draft.tree_id
         }
       }

--- a/spec/controllers/shared_examples/successfully_rendering_view.rb
+++ b/spec/controllers/shared_examples/successfully_rendering_view.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Expect request to be run successfully, including rendering of view
+# This test can be used to verify that instance variables are correctly set when
+# the alternative path in a controller action is taken (e.g. render 'new' in
+# the create action)
+RSpec.shared_examples 'successfully rendering view' do
+  render_views
+
+  it { expect(response).to have_http_status :success }
+
+  it 'successfully renders view' do
+    expect { run_request }.not_to raise_error
+  end
+end

--- a/spec/factories/version_control/revision.rb
+++ b/spec/factories/version_control/revision.rb
@@ -6,7 +6,8 @@ FactoryGirl.define do
 
     transient do
       repository    { build :repository }
-      summary       { Faker::HarryPotter.quote }
+      title         { Faker::HarryPotter.quote }
+      summary       { Faker::Lorem.paragraph }
       author_name   { Faker::Name.name }
       author_email  { "#{author_name.to_param}@example.com" }
       author        { { name: author_name, email: author_email } }
@@ -15,7 +16,7 @@ FactoryGirl.define do
     initialize_with do
       commit =
         repository.lookup(
-          repository.build_revision.commit(summary, author)
+          repository.build_revision.commit(title, summary, author)
         )
       new(repository.revisions, commit)
     end

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -16,8 +16,8 @@ feature 'Revision' do
     click_on 'Files'
     # and click on Commit Changes
     click_on 'Commit Changes'
-    # and enter a revision summary
-    fill_in 'Summary', with: 'Initial Commit'
+    # and enter a revision title
+    fill_in 'Title', with: 'Initial Commit'
     # and click on 'Commit'
     click_on 'Commit'
 

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -32,4 +32,57 @@ feature 'Revision' do
     # and see no file modification icons
     expect(page).to have_css '.file.unchanged', count: 5
   end
+
+  scenario 'User can review changes' do
+    # given there is a project
+    project = create :project
+    # with some files and folders
+    root = create :file, :root, repository: project.repository
+    create_list :file, 5, parent: root
+    folder                      = create :file, :folder, parent: root
+    modified_file               = create :file, parent: folder
+    moved_out_file              = create :file, parent: folder
+    moved_in_file               = create :file, parent: root
+    moved_in_and_modified_file  = create :file, parent: root
+    removed_file                = create :file, parent: folder
+    moved_folder                = create :file, :folder, parent: root
+    create_list :file, 5, parent: moved_folder
+    # and files are committed
+    create :revision, repository: project.repository
+    # and I am signed in as its owner
+    sign_in_as project.owner.account
+
+    # when changes are made to files
+    added_file = create :file, parent: folder
+    modified_file.update(modified_time: Time.zone.now)
+    moved_out_file.update(parent_id: root.id)
+    moved_in_file.update(parent_id: folder.id)
+    moved_in_and_modified_file.update(parent_id: folder.id,
+                                      modified_time: Time.zone.now)
+    removed_file.update(parent_id: nil)
+    moved_folder.update(parent_id: folder.id)
+
+    # when I visit the project page
+    visit "#{project.owner.to_param}/#{project.to_param}"
+    # and click on Files
+    click_on 'Files'
+    # and click on Commit Changes
+    click_on 'Commit Changes'
+
+    # then I can see the changes I am about to commit
+    expect(page).to have_css '.file.added',     text: added_file.name
+    expect(page).to have_css '.file.modified',  text: modified_file.name
+    expect(page).to have_css '.file.moved',     text: moved_out_file.name
+    expect(page).to have_css '.file.moved',     text: moved_in_file.name
+    expect(page).to have_css '.file.moved',
+                             text: moved_in_and_modified_file.name
+    expect(page).to have_css '.file.modified',
+                             text: moved_in_and_modified_file.name
+    expect(page).to have_css '.file.deleted', text: removed_file.name
+    expect(page).to have_css '.file.moved',   text: moved_folder.name
+    # and not see the descendants of moved folders listed
+    moved_folder.children.each do |child|
+      expect(page).not_to have_text child.name
+    end
+  end
 end

--- a/spec/helpers/file_diff_helper_spec.rb
+++ b/spec/helpers/file_diff_helper_spec.rb
@@ -32,36 +32,36 @@ RSpec.describe FileDiffHelper, type: :helper do
     end
   end
 
-  describe '#html_class_for_file_diff(file_diff)' do
-    subject(:method) { html_class_for_file_diff(file_diff) }
+  describe '#html_class_for_file_diff_changes(file_diff_changes)' do
+    subject(:method) { html_class_for_file_diff_changes(file_diff_changes) }
 
-    context 'when base has been added' do
-      before { allow(file_diff).to receive(:added?) { true } }
+    context 'when diff changes are [:added]' do
+      let(:file_diff_changes) { [:added] }
       it { is_expected.to eq 'changed added' }
     end
 
-    context 'when base has been modified' do
-      before { allow(file_diff).to receive(:modified?) { true } }
+    context 'when diff changes are [:modified]' do
+      let(:file_diff_changes) { [:modified] }
       it { is_expected.to eq 'changed modified' }
     end
 
-    context 'when base has been moved' do
-      before { allow(file_diff).to receive(:moved?) { true } }
+    context 'when diff changes are [:moved]' do
+      let(:file_diff_changes) { [:moved] }
       it { is_expected.to eq 'changed moved' }
     end
 
-    context 'when base has been deleted' do
-      before { allow(file_diff).to receive(:deleted?) { true } }
+    context 'when diff changes are [:deleted]' do
+      let(:file_diff_changes) { [:deleted] }
       it { is_expected.to eq 'changed deleted' }
     end
 
-    context 'when base has been modified and moved' do
-      before { allow(file_diff).to receive(:modified?) { true } }
-      before { allow(file_diff).to receive(:moved?) { true } }
+    context 'when diff changes are [:modified, :moved]' do
+      let(:file_diff_changes) { %i[modified moved] }
       it { is_expected.to eq 'changed modified moved' }
     end
 
-    context 'when base has not been changed' do
+    context 'when diff changes are []' do
+      let(:file_diff_changes) { [] }
       it { is_expected.to eq 'unchanged' }
     end
   end
@@ -146,30 +146,36 @@ RSpec.describe FileDiffHelper, type: :helper do
     end
   end
 
-  describe '#text_color_for_file_diff(file_diff)' do
-    subject(:method) { text_color_for_file_diff(file_diff) }
+  describe '#text_color_for_file_diff_change(file_diff_change)' do
+    subject(:method) { text_color_for_file_diff_change(file_diff_change) }
 
-    context 'when base has been added' do
-      before { allow(file_diff).to receive(:added?) { true } }
+    context 'when diff change is :added' do
+      let(:file_diff_change) { :added }
       it { is_expected.to eq 'green-text text-darken-2' }
     end
 
-    context 'when base has been modified' do
-      before { allow(file_diff).to receive(:modified?) { true } }
+    context 'when diff change is :modified' do
+      let(:file_diff_change) { :modified }
       it { is_expected.to eq 'amber-text text-darken-4' }
     end
 
-    context 'when base has been moved' do
-      before { allow(file_diff).to receive(:moved?) { true } }
+    context 'when diff change is :moved' do
+      let(:file_diff_change) { :moved }
       it { is_expected.to eq 'purple-text text-darken-2' }
     end
 
-    context 'when base has been deleted' do
-      before { allow(file_diff).to receive(:deleted?) { true } }
+    context 'when diff change is :deleted' do
+      let(:file_diff_change) { :deleted }
       it { is_expected.to eq 'red-text text-darken-2' }
     end
 
-    context 'when base has not been changed' do
+    context 'when diff change is other' do
+      let(:file_diff_change) { :other }
+      it { is_expected.to eq nil }
+    end
+
+    context 'when diff change is nil' do
+      let(:file_diff_change) { nil }
       it { is_expected.to eq nil }
     end
   end

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe FileHelper, type: :helper do
     end
   end
 
-  describe '#link_to_file(file, project)' do
+  describe '#link_to_file(file, project, options = {})' do
     subject(:method)  { helper.link_to_file(file, project) {} }
     let(:project)     { create :project }
 
@@ -82,13 +82,14 @@ RSpec.describe FileHelper, type: :helper do
 
       it 'returns internal link to directory' do
         expect(helper).to receive(:link_to).with(
-          "/#{project.owner.handle}/#{project.slug}/folders/#{file.id}"
+          "/#{project.owner.handle}/#{project.slug}/folders/#{file.id}",
+          any_args
         )
         method
       end
 
       it 'does not set target to _blank' do
-        expect(helper).to receive(:link_to).with(kind_of(String))
+        expect(helper).to receive(:link_to).with(kind_of(String), {})
         method
       end
     end
@@ -109,6 +110,19 @@ RSpec.describe FileHelper, type: :helper do
           kind_of(String),
           hash_including(target: '_blank')
         )
+        method
+      end
+    end
+
+    context "when options include target: '_blank'" do
+      subject(:method)  { helper.link_to_file(file, project, options) {} }
+      let(:file)        { build :file, :folder }
+      let(:options)     { { target: '_blank' } }
+
+      it 'passes options to #link_to' do
+        expect(helper)
+          .to receive(:link_to)
+          .with(kind_of(String), hash_including(target: '_blank'))
         method
       end
     end

--- a/spec/integrations/version_control/revision_diff_spec.rb
+++ b/spec/integrations/version_control/revision_diff_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'models/shared_examples/version_control/repository_locking.rb'
+
+RSpec.describe VersionControl::RevisionDiff, type: :model do
+  let(:revision_diff) { VersionControl::RevisionDiff.new(base, differentiator) }
+  let(:base)            { repository.stage }
+  let(:differentiator)  { repository.revisions.last }
+  let(:repository)      { build :repository }
+
+  describe '#changed_files_as_diffs' do
+    subject(:method)      { revision_diff.changed_files_as_diffs }
+
+    # create files
+    let!(:root)           { create :file, :root, repository: repository }
+    let!(:folder)         { create :file, :folder, parent: root }
+    let!(:modified_file)  { create :file, parent: folder }
+    let!(:moved_file)     { create :file, parent: root }
+    let!(:deleted_file)   { create :file, parent: root }
+
+    # commit
+    before                { create :revision, repository: repository }
+
+    # make some changes
+    let!(:added_file)     { create :file, :folder, parent: root }
+    before                { modified_file.update modified_time: Time.zone.now }
+    before                { moved_file.update parent_id: folder.id }
+    before                { deleted_file.update parent_id: nil }
+
+    # generate commit draft
+    let(:base)            { repository.build_revision }
+
+    it 'returns four FileDiffs' do
+      expect(method.map(&:class).uniq).to eq [VersionControl::FileDiff]
+      expect(method.count).to eq 4
+    end
+
+    it 'includes the added file' do
+      expect(method.find(&:added?).id).to eq added_file.id
+    end
+
+    it 'includes the modified file' do
+      expect(method.find(&:modified?).id).to eq modified_file.id
+    end
+
+    it 'includes the moved file' do
+      expect(method.find(&:moved?).id).to eq moved_file.id
+    end
+
+    it 'includes the deleted file' do
+      expect(method.find(&:deleted?).id).to eq deleted_file.id
+    end
+
+    context 'when base is a committed revision' do
+      # initialize differentiator
+      let!(:differentiator) { repository.revisions.last }
+      # commit again & initialize base
+      let(:base) { create :revision, repository: repository }
+
+      it 'still returns four FileDiffs' do
+        expect(method.map(&:class).uniq).to eq [VersionControl::FileDiff]
+        expect(method.count).to eq 4
+      end
+    end
+
+    context 'when differentiator is nil' do
+      let(:differentiator) { nil }
+      it 'marks all files as added' do
+        expect(method).to be_all(&:added?)
+        expect(method.count).to eq 4
+      end
+    end
+
+    context 'when no files have changed' do
+      # commit again & initialize differentiator
+      let!(:differentiator) { create :revision, repository: repository }
+      before { repository.revisions.reload }
+      # commit again & initialize base
+      let(:base) { create :revision, repository: repository }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'when changed files include root' do
+      before { root.update modified_time: Time.zone.now }
+
+      it { expect(method.map(&:id)).not_to include root.id }
+    end
+  end
+end

--- a/spec/jobs/folder_import_job_spec.rb
+++ b/spec/jobs/folder_import_job_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe FolderImportJob, type: :job do
     context 'when file already exists' do
       let(:existing_file) do
         build :google_drive_file, :with_id, :with_version_and_time,
-              id: file.id
+              id: file.id, mime_type: file.mime_type
       end
       before do
         FolderImportJob.new.send :create_or_update_file, existing_file,

--- a/spec/models/shared_examples/version_control/being_a_staged_file.rb
+++ b/spec/models/shared_examples/version_control/being_a_staged_file.rb
@@ -206,6 +206,13 @@ RSpec.shared_examples 'being a staged file' do |skip_methods = []|
         expect(persisted_file).to have_attributes params
       end
 
+      it 'does not change mime type' do
+        params[:mime_type] = 'a.new.mime.type'
+        method
+        persisted_file = repository.stage.files.find(file.id)
+        expect(persisted_file.mime_type).not_to eq 'a.new.mime.type'
+      end
+
       it_behaves_like 'being updatable without param key', :name
       it_behaves_like 'being updatable without param key', :parent_id
       it_behaves_like 'being updatable without param key', :mime_type
@@ -422,11 +429,6 @@ RSpec.shared_examples 'being a staged file' do |skip_methods = []|
         it      { expect { method }.to(change { file.name }) }
       end
 
-      context 'when params includes :mime_type' do
-        before  { params.merge! mime_type: 'mime.type.test' }
-        it      { expect { method }.to(change { file.mime_type }) }
-      end
-
       context 'when params includes :version' do
         before  { params.merge! version: file.version + 1 }
         it      { expect { method }.to(change { file.version }) }
@@ -435,6 +437,14 @@ RSpec.shared_examples 'being a staged file' do |skip_methods = []|
       context 'when params includes :modified_time' do
         before  { params.merge! modified_time: Time.zone.now.tomorrow }
         it      { expect { method }.to(change { file.modified_time }) }
+      end
+
+      context 'when params includes :mime_type' do
+        before  { params.merge! mime_type: 'mime.type.test' }
+
+        it 'does not change the existing mime type' do
+          expect { method }.not_to(change { file.mime_type })
+        end
       end
     end
   end

--- a/spec/models/version_control/file_spec.rb
+++ b/spec/models/version_control/file_spec.rb
@@ -40,4 +40,33 @@ RSpec.describe VersionControl::File, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe '.file_path_to_metadata_path(file_path, is_folder)',
+           isolated_unit_test: true do
+    subject(:method) do
+      VersionControl::File.file_path_to_metadata_path path, is_folder
+    end
+    let(:path)      { 'path/to/file' }
+    let(:is_folder) { false }
+
+    it { is_expected.to eq 'path/to/file' }
+
+    context 'when file is a folder' do
+      let(:is_folder) { true }
+
+      it { is_expected.to eq 'path/to/file/.self' }
+    end
+  end
+
+  describe '.metadata_path_to_file_path(metadata_path)',
+           isolated_unit_test: true do
+    subject(:method)  { VersionControl::File.metadata_path_to_file_path path }
+    let(:path)        { 'path/to/file' }
+    it { is_expected.to eq 'path/to/file' }
+
+    context 'when metadata belongs to folder (path ends with .self)' do
+      let(:path) { 'path/to/folder/.self' }
+      it { is_expected.to eq 'path/to/folder' }
+    end
+  end
 end

--- a/spec/models/version_control/revision_diff_spec.rb
+++ b/spec/models/version_control/revision_diff_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'models/shared_examples/caching_method_call.rb'
 require 'models/shared_examples/version_control/repository_locking.rb'
 
 RSpec.describe VersionControl::RevisionDiff, type: :model do
@@ -11,6 +12,74 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
   describe 'attributes' do
     it { should respond_to(:base) }
     it { should respond_to(:differentiator) }
+  end
+
+  describe 'delegations' do
+    it { should delegate_method(:rugged_repository).to(:repository) }
+    it { should delegate_method(:tree).to(:base).with_prefix(true) }
+    it { should delegate_method(:tree).to(:differentiator).with_prefix(true) }
+  end
+
+  describe '#changed_files_as_diffs', isolated_unit_test: true do
+    subject(:method)  { diff.changed_files_as_diffs }
+    let(:diff)        { VersionControl::RevisionDiff.new(base, differentiator) }
+    let(:run_method)  { diff.changed_files_as_diffs }
+    let(:file1)       { instance_double VersionControl::Files::Committed }
+    let(:file2)       { instance_double VersionControl::Files::Committed }
+    let(:file3)       { instance_double VersionControl::Files::Committed }
+    let(:file4)       { instance_double VersionControl::Files::Committed }
+    let(:diff1)       { instance_double VersionControl::FileDiff }
+    let(:diff2)       { instance_double VersionControl::FileDiff }
+    let(:diff3)       { instance_double VersionControl::FileDiff }
+
+    before do
+      expect(file1).to receive(:id).and_return '1'
+      expect(file2).to receive(:id).and_return '2'
+      expect(file3).to receive(:id).and_return '3'
+      expect(file4).to receive(:id).and_return '2'
+    end
+
+    before do
+      expect(diff).to receive(:_files_of_blobs_added_to_base)
+        .exactly(2).times.and_return [file1, file2]
+      expect(diff).to receive(:_files_of_blobs_deleted_from_differentiator)
+        .exactly(2).times.and_return [file3, file4]
+      expect(diff).to receive(:files_to_diffs)
+        .with([file1, file2], [file3, file4], %w[1 2 3])
+        .and_return [diff1, diff2, diff3]
+    end
+
+    it 'returns [diff1, diff2, diff3]' do
+      is_expected.to eq [diff1, diff2, diff3]
+    end
+  end
+
+  describe '#repository', isolated_unit_test: true do
+    subject(:method)  { diff.send :repository }
+    let(:base)        { instance_double VersionControl::Revisions::Committed }
+    let(:differentiator) do
+      instance_double VersionControl::Revisions::Committed
+    end
+    let(:base_repo)           { instance_double VersionControl::Repository }
+    let(:differentiator_repo) { instance_double VersionControl::Repository }
+
+    before do
+      allow(base).to receive(:repository).and_return base_repo
+      allow(differentiator).to receive(:repository)
+        .and_return differentiator_repo
+    end
+
+    it 'returns base repository' do
+      is_expected.to eq base_repo
+    end
+
+    context 'when base is nil' do
+      before { allow(diff).to receive(:base).and_return nil }
+
+      it 'returns differentiator repository' do
+        is_expected.to eq differentiator_repo
+      end
+    end
   end
 
   describe '#diff_file(id)' do
@@ -174,6 +243,188 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
       end
 
       it { expect { |b| diff.lock_if_base_is_stage(&b) }.to yield_with_no_args }
+    end
+  end
+
+  describe '#_files_of_blobs_added_to_base',
+           isolated_unit_test: true do
+    subject(:method)  { diff.send :_files_of_blobs_added_to_base }
+    let(:file1)       { instance_double VersionControl::Files::Committed }
+    let(:file2)       { instance_double VersionControl::Files::Committed }
+    let(:base)        { instance_double VersionControl::Revisions::Committed }
+
+    before do
+      paths = instance_double Array
+      expect(diff).to receive(:_paths_from_rugged_deltas_for)
+        .with(:added_blobs).and_return paths
+
+      base_file_collection =
+        instance_double VersionControl::FileCollections::Committed
+      expect(base).to receive(:files).and_return base_file_collection
+      expect(base_file_collection).to receive(:find_by_path)
+        .with(paths).and_return [file1, file2]
+    end
+
+    it 'returns [file, file2]' do
+      is_expected.to eq [file1, file2]
+    end
+
+    it_behaves_like 'caching method call', :_files_of_blobs_added_to_base do
+      subject { diff }
+    end
+  end
+
+  describe '#_files_of_blobs_deleted_from_differentiator',
+           isolated_unit_test: true do
+    subject(:method)  { diff.send :_files_of_blobs_deleted_from_differentiator }
+    let(:file1)       { instance_double VersionControl::Files::Committed }
+    let(:file2)       { instance_double VersionControl::Files::Committed }
+    let(:differentiator) do
+      instance_double VersionControl::Revisions::Committed
+    end
+
+    context 'when differentiator is present' do
+      before do
+        paths = instance_double Array
+        expect(diff).to receive(:_paths_from_rugged_deltas_for)
+          .with(:deleted_blobs).and_return paths
+
+        differentiator_file_collection =
+          instance_double VersionControl::FileCollections::Committed
+        expect(differentiator).to receive(:files)
+          .and_return differentiator_file_collection
+        expect(differentiator_file_collection).to receive(:find_by_path)
+          .with(paths).and_return [file1, file2]
+      end
+
+      it 'returns [file, file2]' do
+        is_expected.to eq [file1, file2]
+      end
+
+      it_behaves_like 'caching method call',
+                      :_files_of_blobs_deleted_from_differentiator do
+        subject { diff }
+      end
+    end
+
+    context 'when differentiator is nil' do
+      let(:differentiator) { nil }
+
+      it 'returns []' do
+        is_expected.to eq []
+      end
+    end
+  end
+
+  describe '#_filter_delta_file_hashes!(file_hashes)',
+           isolated_unit_test: true do
+    subject(:method)  { diff.send :_filter_delta_file_hashes!, hashes }
+    let(:hashes)      { [root, last_rev, file1, file2, empty] }
+    let(:root)        { { oid: 'sha-oid1', path: 'id-of-root/.self' } }
+    let(:last_rev)    { { oid: 'sha-oid2', path: '.last-revision' } }
+    let(:file1)       { { oid: 'sha-oid3', path: 'id-of-root/file1' } }
+    let(:file2)       { { oid: 'sha-oid4', path: 'id-of-root/folder1/.self' } }
+    let(:empty)       { { oid: '0000000000000000', path: 'id-of-root/empty' } }
+
+    it { is_expected.to eq [file1, file2] }
+
+    it 'filters out the root folder' do
+      is_expected.not_to include root
+    end
+
+    it 'filters out the .last-revision file' do
+      is_expected.not_to include last_rev
+    end
+
+    it 'filters out empty blobs' do
+      is_expected.not_to include empty
+    end
+  end
+
+  describe '#_paths_from_rugged_deltas_for(type_of_blobs)',
+           isolated_unit_test: true do
+    subject(:method) { diff.send :_paths_from_rugged_deltas_for, type_of_blobs }
+    let(:delta1)  { instance_double Rugged::Diff::Delta }
+    let(:delta2)  { instance_double Rugged::Diff::Delta }
+    let(:delta3)  { instance_double Rugged::Diff::Delta }
+    let(:delta4)  { instance_double Rugged::Diff::Delta }
+    let(:file1)   { { oid: 'sha-oid1', path: 'path/to/file1' } }
+    let(:file2)   { { oid: 'sha-oid2', path: 'path/to/file2' } }
+    let(:file3)   { { oid: 'sha-oid3', path: 'path/to/file3' } }
+    let(:file4)   { { oid: 'sha-oid3', path: 'path/to/folder/.self' } }
+
+    before do
+      expect(diff).to receive(:_rugged_deltas)
+        .and_return [delta1, delta2, delta3, delta4]
+      expect(delta1).to receive(file_hash_key).and_return file1
+      expect(delta2).to receive(file_hash_key).and_return file2
+      expect(delta3).to receive(file_hash_key).and_return file3
+      expect(delta4).to receive(file_hash_key).and_return file4
+      expect(diff).to receive(:_filter_delta_file_hashes!)
+        .with([file1, file2, file3, file4]) { |hash| hash.delete_at 2 }
+      expect(VersionControl::File).to receive(:metadata_path_to_file_path)
+        .with('path/to/file1').and_return 'path/to/file1'
+      expect(VersionControl::File).to receive(:metadata_path_to_file_path)
+        .with('path/to/file2').and_return 'path/to/file2'
+      expect(VersionControl::File).to receive(:metadata_path_to_file_path)
+        .with('path/to/folder/.self').and_return 'path/to/folder'
+    end
+
+    context 'when type_of_blobs = :added_blobs' do
+      let(:type_of_blobs) { :added_blobs }
+      let(:file_hash_key) { :new_file }
+
+      it "returns ['path/to/file1', 'path/to/file2', 'path/to/folder']" do
+        is_expected.to eq ['path/to/file1', 'path/to/file2', 'path/to/folder']
+      end
+
+      it 'filters out file3' do
+        is_expected.not_to include 'path/to/file3'
+      end
+    end
+
+    context 'when type_of_blobs = :deleted_blobs' do
+      let(:type_of_blobs) { :deleted_blobs }
+      let(:file_hash_key) { :old_file }
+
+      it "returns ['path/to/file1', 'path/to/file2', 'path/to/folder']" do
+        is_expected.to eq ['path/to/file1', 'path/to/file2', 'path/to/folder']
+      end
+
+      it 'filters out file3' do
+        is_expected.not_to include 'path/to/file3'
+      end
+    end
+  end
+
+  describe '#_rugged_deltas', isolated_unit_test: true do
+    subject(:method)  { diff.send :_rugged_deltas }
+    let(:rugged_repo) { instance_double Rugged::Repository }
+    # let(:base)        { instance_double VersionControl::Revisions::Committed }
+    let(:base_tree)   { instance_double Rugged::Tree }
+    let(:differentiator_tree) { instance_double Rugged::Tree }
+    let(:rugged_diff)         { instance_double Rugged::Diff }
+    let(:delta1)              { instance_double Rugged::Diff::Delta }
+    let(:delta2)              { instance_double Rugged::Diff::Delta }
+
+    before do
+      expect(diff).to receive(:rugged_repository).and_return rugged_repo
+      expect(diff).to receive(:base_tree).and_return base_tree
+      expect(diff).to receive(:differentiator_tree)
+        .and_return differentiator_tree
+      # expect(base).to receive(:tree).and_return base_tree
+      expect(Rugged::Tree).to receive(:diff)
+        .with(rugged_repo, differentiator_tree, base_tree)
+        .and_return rugged_diff
+      expect(rugged_diff).to receive(:deltas).and_return [delta1, delta2]
+    end
+
+    it 'returns [delta1, delta2]' do
+      is_expected.to eq [delta1, delta2]
+    end
+
+    it_behaves_like 'caching method call', :_rugged_deltas do
+      subject { diff }
     end
   end
 end

--- a/spec/models/version_control/revisions/drafted_spec.rb
+++ b/spec/models/version_control/revisions/drafted_spec.rb
@@ -111,6 +111,26 @@ RSpec.describe VersionControl::Revisions::Drafted, type: :model do
     end
   end
 
+  describe '#files', isolated_unit_test: true do
+    subject(:method) { revision.files }
+    let(:file_collection) do
+      instance_double VersionControl::FileCollections::Committed
+    end
+
+    before do
+      expect(VersionControl::FileCollections::Committed)
+        .to receive(:new).with(revision).and_return file_collection
+    end
+
+    it 'returns the file collection' do
+      is_expected.to eq file_collection
+    end
+
+    it_behaves_like 'caching method call', :files do
+      subject { revision }
+    end
+  end
+
   describe '#tree' do
     subject(:method)  { revision.tree }
     let(:tree_id)     { revision.instance_variable_get :@tree_id }

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe 'revisions/new', type: :view do
     expect(rendered).to have_css 'input#revision_title'
   end
 
-
   it 'has a text area for revision summary' do
     render
     expect(rendered).to have_css 'textarea#revision_summary'

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -39,6 +39,12 @@ RSpec.describe 'revisions/new', type: :view do
     )
   end
 
+  it 'has a text field for revision titile' do
+    render
+    expect(rendered).to have_css 'input#revision_title'
+  end
+
+
   it 'has a text area for revision summary' do
     render
     expect(rendered).to have_css 'textarea#revision_summary'


### PR DESCRIPTION
When a user clicks on 'Commit Changes' and is prompted to provide a revision summary, the user can also review the list of file changes that they are about to commit.