### PR TITLE
Add revision history to projects

### DIFF
--- a/app/assets/stylesheets/controllers/revisions.scss
+++ b/app/assets/stylesheets/controllers/revisions.scss
@@ -2,10 +2,16 @@
 
 .c-revisions {
 
+  .revision .title {
+    line-height: 32px; // match line height of timestamp
+  }
+
+  // create a very slight overlay effect where the author name touches the
+  // bottom of the author profile picture
   .revision .author-name {
-    margin-bottom: -15px;
+    margin-bottom: -10px;
     position: relative;
-    top: -15px;
+    top: -10px;
   }
 
   h3 {

--- a/app/assets/stylesheets/controllers/revisions.scss
+++ b/app/assets/stylesheets/controllers/revisions.scss
@@ -33,6 +33,9 @@
   .file {
     // scss-lint:disable NestingDepth
 
+    margin-bottom: 2px;
+    margin-top: 2px;
+
     .file-icon {
       float: left;
       height: 30px;

--- a/app/assets/stylesheets/controllers/revisions.scss
+++ b/app/assets/stylesheets/controllers/revisions.scss
@@ -2,6 +2,12 @@
 
 .c-revisions {
 
+  .revision .author-name {
+    margin-bottom: -15px;
+    position: relative;
+    top: -15px;
+  }
+
   h3 {
     position: relative;
     z-index: 1;

--- a/app/assets/stylesheets/shared/spacing.scss
+++ b/app/assets/stylesheets/shared/spacing.scss
@@ -7,7 +7,7 @@
   height: 1px;
 }
 
-@each $factor in 1, 2, 3, 4, 8 {
+@each $factor in .5, 1, 2, 3, 4, 8 {
   div.spacing.v#{$factor * $base-unit} {
     display: block;
     height: $factor * $base-unit;

--- a/app/controllers/concerns/can_set_project_context.rb
+++ b/app/controllers/concerns/can_set_project_context.rb
@@ -20,9 +20,17 @@ module CanSetProjectContext
   # the page (link to Files, link to Google Drive, link to revisions)
   def set_project_context
     _set_root_folder
+    _set_has_revisions
   end
 
   def _set_root_folder
     @root_folder = @project.files.root
+  end
+
+  def _set_has_revisions
+    # TODO: Add #revisions directly to project (delegate to repository)
+    # TODO: Add method #any? to RevisionsCollection
+    # Final output: @project.revisions.any?
+    @has_revisions = @project.repository.revisions.last.present?
   end
 end

--- a/app/controllers/concerns/can_set_project_context.rb
+++ b/app/controllers/concerns/can_set_project_context.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Define setter method for setting the instance variables needed to correctly
+# display the project header (@project, @roo_folder, @has_revisions, ...)
+module CanSetProjectContext
+  extend ActiveSupport::Concern
+
+  included do
+    include ProjectLockable
+  end
+
+  private
+
+  # Find and set project. Raise 404 if project does not exist
+  def set_project
+    @project = Project.find(params[:profile_handle], params[:project_slug])
+  end
+
+  # Set instance variables needed to render the project header on the top of
+  # the page (link to Files, link to Google Drive, link to revisions)
+  def set_project_context
+    _set_root_folder
+  end
+
+  def _set_root_folder
+    @root_folder = @project.files.root
+  end
+end

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -2,6 +2,7 @@
 
 # Controller for project folders
 class FoldersController < ApplicationController
+  include CanSetProjectContext
   include ProjectLockable
 
   # Execute without lock or render/redirect delay
@@ -10,10 +11,10 @@ class FoldersController < ApplicationController
   around_action :wrap_action_in_project_lock
 
   # Execute with lock and render/redirect delay
+  before_action :set_project_context
   before_action :set_folder_diff
   before_action :set_file_diffs
   before_action :set_ancestors
-  before_action :set_root_folder
   before_action :set_user_can_commit_changes
 
   def root
@@ -43,14 +44,6 @@ class FoldersController < ApplicationController
 
     # Raise error if folder is not a directory
     raise ActiveRecord::RecordNotFound unless @folder_diff.directory?
-  end
-
-  def set_project
-    @project = Project.find(params[:profile_handle], params[:project_slug])
-  end
-
-  def set_root_folder
-    @root_folder = @project.files.root
   end
 
   def set_user_can_commit_changes

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,6 +2,7 @@
 
 # Controller for projects
 class ProjectsController < ApplicationController
+  include CanSetProjectContext
   include ProjectLockable
 
   # Execute without lock or render/redirect delay
@@ -11,6 +12,9 @@ class ProjectsController < ApplicationController
   before_action :authorize_action, only: %i[setup import edit update destroy]
 
   around_action :wrap_action_in_project_lock, only: :show
+
+  # Execute with lock and render/redirect delay
+  before_action :set_project_context, only: :show
 
   def new; end
 
@@ -43,7 +47,6 @@ class ProjectsController < ApplicationController
   end
 
   def show
-    @root_folder = @project.files.root
     @user_can_edit_project = can?(:edit, @project)
   end
 

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -2,6 +2,7 @@
 
 # Controller for project revisions
 class RevisionsController < ApplicationController
+  include CanSetProjectContext
   include ProjectLockable
 
   # Execute without lock or render/redirect delay
@@ -12,9 +13,9 @@ class RevisionsController < ApplicationController
   around_action :wrap_action_in_project_lock
 
   # Execute with lock and render/redirect delay
+  before_action :set_project_context
   before_action :build_revision
   before_action :set_file_diffs, only: :new
-  before_action :set_root_folder
 
   def new; end
 
@@ -64,14 +65,6 @@ class RevisionsController < ApplicationController
     set_ancestors_of_file_diffs
 
     helpers.sort_file_diffs!(@file_diffs)
-  end
-
-  def set_project
-    @project = Project.find(params[:profile_handle], params[:project_slug])
-  end
-
-  def set_root_folder
-    @root_folder = @project.files.root
   end
 
   def revision_params

--- a/app/helpers/file_helper.rb
+++ b/app/helpers/file_helper.rb
@@ -62,15 +62,17 @@ module FileHelper
   #
   # Files are sorted by:
   # 1) directory first and
-  # 2) file name in ascending order
+  # 2) file name in ascending alphabetical order case insensitive
   #
   # Example use:
   # files.sort_by! { |file| sort_order_for_files(file) }
   # file_diffs.sort_by! { |diff| sort_order_for_files(diff.file_is_or_was) }
   def sort_order_for_files(file)
     [
-      (file.directory? ? 0 : 1),  # put directories first
-      file.name                   # then sort by name in ascending order
+      # put directories first
+      (file.directory? ? 0 : 1),
+      # then sort by name in ascending order (case insensitive)
+      file.name.downcase
     ]
   end
 

--- a/app/models/version_control/revision_collection.rb
+++ b/app/models/version_control/revision_collection.rb
@@ -4,26 +4,44 @@ module VersionControl
   # A collection of revisions for a version controlled repository
   class RevisionCollection
     attr_reader :repository
-    delegate :lock, to: :repository
+    delegate :lock, :rugged_repository, to: :repository
 
     def initialize(repository)
       @repository = repository
     end
 
+    # Return an array of VersionControl:Revisions that include all revisions in
+    # this repository
+    def all
+      return @all if @all
+
+      rugged_commits = Rugged::Walker.walk(rugged_repository,
+                                           show: _last_rugged_commit,
+                                           simplify: true)
+
+      @all =
+        rugged_commits.map do |commit|
+          VersionControl::Revisions::Committed.new(self, commit)
+        end
+    end
+
     # Return the last (most recent) revision in this repository
     def last
       return @last if @last
-
-      last_commit = repository.rugged_repository.branches['master']&.target
-
-      @last =
-        last_commit.present? ? Revisions::Committed.new(self, last_commit) : nil
+      return nil unless _last_rugged_commit
+      @last ||= Revisions::Committed.new(self, _last_rugged_commit)
     end
 
     # Resets cached instance variables and returns self for chaining
     def reload
       @last = nil
       self
+    end
+
+    private
+
+    def _last_rugged_commit
+      rugged_repository.branches['master']&.target
     end
   end
 end

--- a/app/models/version_control/revisions/committed.rb
+++ b/app/models/version_control/revisions/committed.rb
@@ -18,6 +18,14 @@ module VersionControl
       def files
         @files ||= FileCollections::Committed.new(self)
       end
+
+      def summary
+        @summary ||= @commit.message.split("\r\n\r\n", 2)[1]
+      end
+
+      def title
+        @title ||= @commit.message.split("\r\n\r\n").first
+      end
     end
   end
 end

--- a/app/models/version_control/revisions/committed.rb
+++ b/app/models/version_control/revisions/committed.rb
@@ -15,6 +15,10 @@ module VersionControl
         @id                   = commit.oid
       end
 
+      def author_email
+        @commit.author[:email]
+      end
+
       def files
         @files ||= FileCollections::Committed.new(self)
       end

--- a/app/models/version_control/revisions/committed.rb
+++ b/app/models/version_control/revisions/committed.rb
@@ -19,6 +19,10 @@ module VersionControl
         @commit.author[:email]
       end
 
+      def created_at
+        @commit.author[:time]
+      end
+
       def files
         @files ||= FileCollections::Committed.new(self)
       end

--- a/app/views/projects/_head.slim
+++ b/app/views/projects/_head.slim
@@ -22,6 +22,10 @@
               div.tab
                 = link_to 'Files', profile_project_root_folder_path(@project.owner, @project),
                           class: ('active' if active_tab == :files)
+            - if @has_revisions
+              div.tab
+                = link_to 'Revisions', profile_project_revisions_path(@project.owner, @project),
+                          class: ('active' if active_tab == :revisions)
             - if @root_folder
               div.tab
                 = link_to external_link_for_file(@root_folder), target: '_blank' do

--- a/app/views/revisions/_file_diff.slim
+++ b/app/views/revisions/_file_diff.slim
@@ -3,5 +3,5 @@
 = render partial: 'file_diff_change',
          collection: file_diff.changes,
          locals: { file_diff: file_diff,
-                   ancestors: ancestors,
+                   ancestors: file_diff.ancestors_of_file,
                    project: project }

--- a/app/views/revisions/_revision.slim
+++ b/app/views/revisions/_revision.slim
@@ -1,3 +1,8 @@
 .metadata
-  h5.title: b = revision.title
+  h5.title
+    = link_to anchor: revision.id do
+      span.chip.right
+        => time_ago_in_words(revision.created_at)
+        | ago
+    b = revision.title
   p.summary = revision.summary

--- a/app/views/revisions/_revision.slim
+++ b/app/views/revisions/_revision.slim
@@ -1,0 +1,3 @@
+.metadata
+  h5.title: b = revision.title
+  p.summary = revision.summary

--- a/app/views/revisions/_revision.slim
+++ b/app/views/revisions/_revision.slim
@@ -3,4 +3,5 @@
     = render partial: 'revision_timestamp',
              locals: { revision: revision, device: :desktop }
     b = revision.title
-  p.summary = revision.summary
+  .summary
+    = simple_format html_escape(revision.summary)

--- a/app/views/revisions/_revision.slim
+++ b/app/views/revisions/_revision.slim
@@ -1,8 +1,6 @@
 .metadata
   h5.title
-    = link_to anchor: revision.id do
-      span.chip.right
-        => time_ago_in_words(revision.created_at)
-        | ago
+    = render partial: 'revision_timestamp',
+             locals: { revision: revision, device: :desktop }
     b = revision.title
   p.summary = revision.summary

--- a/app/views/revisions/_revision_author.slim
+++ b/app/views/revisions/_revision_author.slim
@@ -1,9 +1,11 @@
 .author
   = link_to profile_path(revision_author) do
 
-    = image_tag 'profiles/picture.jpg', size: '70', class: 'responsive-img circle'
+    = image_tag 'profiles/picture.jpg',
+                size: '70',
+                class: 'responsive-img circle z-depth-1'
 
     br
 
-    span.chip.author-name
+    span.chip.author-name.z-depth-1.white.black-text
       = revision_author.name

--- a/app/views/revisions/_revision_author.slim
+++ b/app/views/revisions/_revision_author.slim
@@ -1,0 +1,9 @@
+.author
+  = link_to profile_path(revision_author) do
+
+    = image_tag 'profiles/picture.jpg', size: '70', class: 'responsive-img circle'
+
+    br
+
+    span.chip.author-name
+      = revision_author.name

--- a/app/views/revisions/_revision_diff.slim
+++ b/app/views/revisions/_revision_diff.slim
@@ -1,0 +1,9 @@
+/ render file changes
+/ TODO: Is this the right place for sorting?
+- file_diffs = revision_diff.changed_files_as_diffs.select(&:changed?)
+- sort_file_diffs! file_diffs
+
+.revision-diff
+  = render(partial: 'file_diff',
+           collection: file_diffs,
+           locals: { project: project }) || '<i>No files changed.</i>'.html_safe

--- a/app/views/revisions/_revision_timestamp.slim
+++ b/app/views/revisions/_revision_timestamp.slim
@@ -1,0 +1,12 @@
+/ render the revision's timestamp and a direct link to the revision
+- if device == :desktop
+  - class_tag = 'hide-on-small-only'
+  - is_slim   = false
+- elsif device == :mobile
+  - class_tag = 'hide-on-med-and-up'
+  - is_slim   = true
+
+= link_to({ anchor: revision.id }, class: class_tag ) do
+  span.chip.right[class=('slim' if is_slim)]
+    => time_ago_in_words(revision.created_at)
+    | ago

--- a/app/views/revisions/index.slim
+++ b/app/views/revisions/index.slim
@@ -3,7 +3,7 @@
   .spacing.v16px
 
   - (@revisions + [nil]).each_cons(2) do |this_revision, previous_revision|
-    .row.revision[data-revision-id=this_revision.id]
+    .row.revision id=this_revision.id
 
       .spacing.v16px
 

--- a/app/views/revisions/index.slim
+++ b/app/views/revisions/index.slim
@@ -1,16 +1,25 @@
 .container
 
-  .spacing.v32px
+  .spacing.v16px
 
   - (@revisions + [nil]).each_cons(2) do |this_revision, previous_revision|
-    .revision[data-revision-id=this_revision.id]
-      = render partial: 'revision', object: this_revision
+    .row.revision[data-revision-id=this_revision.id]
 
-      / TODO: this is probably not the right place to generate a diff
-      = render partial: 'revision_diff',
-               object: this_revision.diff(previous_revision),
-               locals: { project: @project }
+      .spacing.v16px
 
-    .spacing.v16px
-    .divider
-    .spacing.v16px
+      .col.l2.m3.s12.center-align
+        = render partial: 'revision_author',
+                 object: Profiles::User.find_by_id(this_revision.author_email)
+
+      .col.l10.m9.s12
+        = render partial: 'revision', object: this_revision
+
+        / TODO: this is probably not the right place to generate a diff
+        = render partial: 'revision_diff',
+                 object: this_revision.diff(previous_revision),
+                 locals: { project: @project }
+
+    - if previous_revision.present?
+      .divider
+
+.spacing.v48px

--- a/app/views/revisions/index.slim
+++ b/app/views/revisions/index.slim
@@ -1,0 +1,16 @@
+.container
+
+  .spacing.v32px
+
+  - (@revisions + [nil]).each_cons(2) do |this_revision, previous_revision|
+    .revision[data-revision-id=this_revision.id]
+      = render partial: 'revision', object: this_revision
+
+      / TODO: this is probably not the right place to generate a diff
+      = render partial: 'revision_diff',
+               object: this_revision.diff(previous_revision),
+               locals: { project: @project }
+
+    .spacing.v16px
+    .divider
+    .spacing.v16px

--- a/app/views/revisions/index.slim
+++ b/app/views/revisions/index.slim
@@ -5,7 +5,13 @@
   - (@revisions + [nil]).each_cons(2) do |this_revision, previous_revision|
     .row.revision id=this_revision.id
 
-      .spacing.v16px
+      .spacing.v8px
+
+      = render partial: 'revision_timestamp',
+               locals: { revision: this_revision, device: :mobile }
+
+      .spacing.v8px
+
 
       .col.l2.m3.s12.center-align
         = render partial: 'revision_author',

--- a/app/views/revisions/new.slim
+++ b/app/views/revisions/new.slim
@@ -39,14 +39,9 @@
     .spacing.v1
 
     h3: span Review Changes
-    / render preview of file changes
-    - if @file_diffs.none?
-      | There are no changes to review.
-    - else
-      - @file_diffs.each do |diff|
-        = render partial: 'file_diff',
-                 object: diff,
-                 locals: { ancestors: @ancestors_of_file_diffs[diff.id],
-                           project: @project }
+    // TODO: This is probably not the right place to generate a diff
+    = render partial: 'revision_diff',
+             object: @revision.diff(@project.repository.revisions.last),
+             locals: { project: @project }
 
     .spacing.v48px

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
       # Route for folders
       get 'files' => 'folders#root', as: :root_folder
       resources :folders, only: :show
-      resources :revisions, only: %i[new create]
+      resources :revisions, only: %i[index new create]
     end
   end
 

--- a/spec/controllers/folders_controller_spec.rb
+++ b/spec/controllers/folders_controller_spec.rb
@@ -2,6 +2,7 @@
 
 require 'controllers/shared_examples/a_repository_locking_action.rb'
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
+require 'controllers/shared_examples/setting_project_context.rb'
 
 RSpec.describe FoldersController, type: :controller do
   let!(:folder)         { create :file, :root, repository: project.repository }
@@ -25,6 +26,7 @@ RSpec.describe FoldersController, type: :controller do
       before { FileUtils.remove_dir(folder.send(:path)) }
     end
     it_should_behave_like 'a repository locking action'
+    it_should_behave_like 'setting project context'
 
     it 'returns http success' do
       run_request
@@ -43,6 +45,7 @@ RSpec.describe FoldersController, type: :controller do
       before { FileUtils.remove_dir(folder.send(:path)) }
     end
     it_should_behave_like 'a repository locking action'
+    it_should_behave_like 'setting project context'
 
     context 'when file is not a directory' do
       let(:file)  { create :file, parent: folder }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -5,6 +5,7 @@ require 'controllers/shared_examples/a_repository_locking_action.rb'
 require 'controllers/shared_examples/an_authenticated_action.rb'
 require 'controllers/shared_examples/an_authorized_action.rb'
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
+require 'controllers/shared_examples/setting_project_context.rb'
 
 RSpec.describe ProjectsController, type: :controller do
   let!(:project)        { create(:project) }
@@ -128,6 +129,7 @@ RSpec.describe ProjectsController, type: :controller do
     include_examples 'raise 404 if non-existent', Profiles::Base
     include_examples 'raise 404 if non-existent', Project
     it_should_behave_like 'a repository locking action'
+    it_should_behave_like 'setting project context'
 
     it 'returns http success' do
       run_request

--- a/spec/controllers/revisions_controller_spec.rb
+++ b/spec/controllers/revisions_controller_spec.rb
@@ -6,6 +6,7 @@ require 'controllers/shared_examples/an_authenticated_action.rb'
 require 'controllers/shared_examples/an_authorized_action.rb'
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
 require 'controllers/shared_examples/successfully_rendering_view.rb'
+require 'controllers/shared_examples/setting_project_context.rb'
 
 RSpec.describe RevisionsController, type: :controller do
   let!(:project)        { create :project }
@@ -31,6 +32,7 @@ RSpec.describe RevisionsController, type: :controller do
       end
     end
     it_should_behave_like 'a repository locking action'
+    it_should_behave_like 'setting project context'
 
     it 'returns http success' do
       run_request
@@ -62,6 +64,7 @@ RSpec.describe RevisionsController, type: :controller do
       end
     end
     it_should_behave_like 'a repository locking action'
+    it_should_behave_like 'setting project context'
 
     it_should_behave_like 'a redirect with success' do
       let(:redirect_location) do

--- a/spec/controllers/revisions_controller_spec.rb
+++ b/spec/controllers/revisions_controller_spec.rb
@@ -17,6 +17,21 @@ RSpec.describe RevisionsController, type: :controller do
     }
   end
 
+  describe 'GET #index' do
+    let(:params)      { default_params }
+    let(:run_request) { get :index, params: params }
+
+    include_examples 'raise 404 if non-existent', Profiles::Base
+    include_examples 'raise 404 if non-existent', Project
+    it_should_behave_like 'a repository locking action'
+    it_should_behave_like 'setting project context'
+
+    it 'returns http success' do
+      run_request
+      expect(response).to have_http_status :success
+    end
+  end
+
   describe 'GET #new' do
     let(:params)      { default_params }
     let(:run_request) { get :new, params: params }

--- a/spec/controllers/shared_examples/setting_project_context.rb
+++ b/spec/controllers/shared_examples/setting_project_context.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Expect the controller action to call #set_project and #set_project_context
+# methods required to correctly render the project head
+RSpec.shared_examples 'setting project context' do
+  after { run_request }
+  it    { is_expected.to receive(:set_project).and_call_original }
+  it    { is_expected.to receive(:set_project_context) }
+end

--- a/spec/factories/version_control/revision.rb
+++ b/spec/factories/version_control/revision.rb
@@ -8,15 +8,14 @@ FactoryGirl.define do
       repository    { build :repository }
       title         { Faker::HarryPotter.quote }
       summary       { Faker::Lorem.paragraph }
-      author_name   { Faker::Name.name }
-      author_email  { "#{author_name.to_param}@example.com" }
-      author        { { name: author_name, email: author_email } }
+      author        { create :user }
+      author_hash   { { name: author.handle, email: author.id.to_s } }
     end
 
     initialize_with do
       commit =
         repository.lookup(
-          repository.build_revision.commit(title, summary, author)
+          repository.build_revision.commit(title, summary, author_hash)
         )
       new(repository.revisions, commit)
     end

--- a/spec/factories/version_control/revision.rb
+++ b/spec/factories/version_control/revision.rb
@@ -20,5 +20,9 @@ FactoryGirl.define do
         )
       new(repository.revisions, commit)
     end
+
+    after(:create) do |revision|
+      revision.revision_collection.reload
+    end
   end
 end

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -27,7 +27,7 @@ feature 'Revision' do
     click_on 'Revisions'
 
     # then I should see each revision in reverse chronological order
-    expect(page.find_all('.revision .metadata .title').map(&:text))
+    expect(page.find_all('.revision .metadata .title b').map(&:text))
       .to eq [third_revision, second_revision, first_revision].map(&:title)
     # with their author
     expect(page.find_all('.revision .author').map(&:text))

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -7,11 +7,19 @@ feature 'Revision' do
     # with three revisions and a file added/modified/destroyed in between
     root = create :file, :root, repository: project.repository
     file = create :file, name: 'File1', parent: root
-    first_revision = create :revision, repository: project.repository
+    users = create_list :user, 3
+    # TODO: This is not a complete feature test because it relies on the
+    # =>    assumption that the author's ID is stored in the email field when
+    # =>    a commit is made. If that implementation changes, this spec would
+    # =>    still pass.
+    first_revision =
+      create :revision, repository: project.repository, author: users[0]
     file.update(modified_time: Time.zone.now)
-    second_revision = create :revision, repository: project.repository
+    second_revision =
+      create :revision, repository: project.repository, author: users[1]
     file.destroy
-    third_revision = create :revision, repository: project.repository
+    third_revision =
+      create :revision, repository: project.repository, author: users[2]
 
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"
@@ -21,6 +29,9 @@ feature 'Revision' do
     # then I should see each revision in reverse chronological order
     expect(page.find_all('.revision .metadata .title').map(&:text))
       .to eq [third_revision, second_revision, first_revision].map(&:title)
+    # with their author
+    expect(page.find_all('.revision .author').map(&:text))
+      .to eq [users.last.name, users.second.name, users.first.name]
     # and see file changes for each revision
     expect(page.find_all('.revision-diff').map(&:text)).to eq(
       ['File1 deleted from Home', 'File1 modified', 'File1 added to Home']

--- a/spec/helpers/file_diff_helper_spec.rb
+++ b/spec/helpers/file_diff_helper_spec.rb
@@ -103,10 +103,10 @@ RSpec.describe FileDiffHelper, type: :helper do
       ].shuffle
     end
     let(:dir1)        { build :file, :folder, name: 'A Folder' }
-    let(:dir2)        { build :file, :folder, name: 'Homework' }
+    let(:dir2)        { build :file, :folder, name: 'homework' }
     let(:dir3)        { build :file, :folder, name: 'Something Great' }
     let(:file1)       { build :file, name: 'A Funny File' }
-    let(:file2)       { build :file, name: 'Financials' }
+    let(:file2)       { build :file, name: 'financials' }
     let(:file3)       { build :file, name: 'Potato Soup Recipe' }
 
     it 'sorts file diffs in correct order' do
@@ -124,12 +124,13 @@ RSpec.describe FileDiffHelper, type: :helper do
       expect(file_diffs[3..5].map(&:directory?)).to eq [false, false, false]
     end
 
-    it 'puts file diffs in alphabetical order' do
+    it 'puts file diffs in alphabetical order (case insensitive)' do
       subject
       last_file_diff = file_diffs[0]
       file_diffs[1..2].each do |file_diff|
         # expect file name to come later (alphabetically) than last file's name
-        expect(file_diff.name > last_file_diff.name).to be true
+        expect(file_diff.name.downcase > last_file_diff.name.downcase)
+          .to be true
 
         # set last_file_diffs to current file_diffs for next comparison
         last_file_diff = file_diff
@@ -138,7 +139,8 @@ RSpec.describe FileDiffHelper, type: :helper do
       last_file_diff = file_diffs[3]
       file_diffs[4..5].each do |file_diff|
         # expect file name to come later (alphabetically) than last file's name
-        expect(file_diff.name > last_file_diff.name).to be true
+        expect(file_diff.name.downcase > last_file_diff.name.downcase)
+          .to be true
 
         # set last_file_diffs to current file_diffs for next comparison
         last_file_diff = file_diff

--- a/spec/helpers/file_helper_spec.rb
+++ b/spec/helpers/file_helper_spec.rb
@@ -133,9 +133,9 @@ RSpec.describe FileHelper, type: :helper do
     let(:files)       { [dir1, dir2, dir3, file1, file2, file3].shuffle }
     let(:dir1)        { build :file, :folder, name: 'A Folder' }
     let(:dir2)        { build :file, :folder, name: 'Homework' }
-    let(:dir3)        { build :file, :folder, name: 'Something Great' }
+    let(:dir3)        { build :file, :folder, name: 'something Great' }
     let(:file1)       { build :file, name: 'A Funny File' }
-    let(:file2)       { build :file, name: 'Financials' }
+    let(:file2)       { build :file, name: 'financials' }
     let(:file3)       { build :file, name: 'Potato Soup Recipe' }
 
     it { is_expected.to eq [dir1, dir2, dir3, file1, file2, file3] }
@@ -150,12 +150,12 @@ RSpec.describe FileHelper, type: :helper do
       expect(files[3..5].map(&:directory?)).to eq [false, false, false]
     end
 
-    it 'puts files in alphabetical order' do
+    it 'puts files in alphabetical order (case insensitive)' do
       subject
       last_file = files[0]
       files[1..2].each do |file|
         # expect file name to come later (alphabetically) than last_file's name
-        expect(file.name > last_file.name).to be true
+        expect(file.name.downcase > last_file.name.downcase).to be true
 
         # set last_file to current file for next comparison
         last_file = file
@@ -164,7 +164,7 @@ RSpec.describe FileHelper, type: :helper do
       last_file = files[3]
       files[4..5].each do |file|
         # expect file name to come later (alphabetically) than last_file's name
-        expect(file.name > last_file.name).to be true
+        expect(file.name.downcase > last_file.name.downcase).to be true
 
         # set last_file to current file for next comparison
         last_file = file
@@ -178,14 +178,18 @@ RSpec.describe FileHelper, type: :helper do
 
     it { is_expected.to be_an Array }
 
+    it 'parses file names as case insensitive' do
+      expect(method.last).to eq 'file name'
+    end
+
     context 'when file is directory' do
       before { allow(file).to receive(:directory?).and_return true }
-      it { is_expected.to eq [0, 'File Name'] }
+      it { is_expected.to eq [0, 'file name'] }
     end
 
     context 'when file is not directory' do
       before { allow(file).to receive(:directory?).and_return false }
-      it { is_expected.to eq [1, 'File Name'] }
+      it { is_expected.to eq [1, 'file name'] }
     end
   end
 

--- a/spec/integrations/version_control/revision_collection_spec.rb
+++ b/spec/integrations/version_control/revision_collection_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+RSpec.describe VersionControl::RevisionCollection, type: :model do
+  subject(:revision_collection) { repository.revisions }
+  let(:repository)              { build :repository }
+
+  describe '#all' do
+    subject(:method)        { revision_collection.all }
+    let!(:oldest_revision)  { create :revision, repository: repository }
+    let!(:second_revision)  { create :revision, repository: repository }
+    let!(:newest_revision)  { create :revision, repository: repository }
+
+    it 'returns all three revisions' do
+      expect(method.map(&:id)).to contain_exactly(
+        newest_revision.id, second_revision.id, oldest_revision.id
+      )
+    end
+
+    it 'returns the newest revision as the first element in the array' do
+      expect(method.first.id).to eq newest_revision.id
+    end
+
+    it 'returns the oldest revision as the last element in the array' do
+      expect(method.last.id).to eq oldest_revision.id
+    end
+
+    context 'when no revisions exist' do
+      let(:revision_collection) { build(:repository).revisions }
+
+      it { is_expected.to eq [] }
+    end
+  end
+end

--- a/spec/models/version_control/revision_collection_spec.rb
+++ b/spec/models/version_control/revision_collection_spec.rb
@@ -15,6 +15,43 @@ RSpec.describe VersionControl::RevisionCollection, type: :model do
       expect_any_instance_of(VersionControl::Repository).to receive :lock
       subject.lock
     end
+    it { is_expected.to delegate_method(:rugged_repository).to(:repository) }
+  end
+
+  describe '#all', isolated_unit_test: true do
+    subject(:method)    { collection.all }
+    let(:collection)    { VersionControl::RevisionCollection.new(nil) }
+    let(:rugged_repo)   { instance_double Rugged::Repository }
+    let(:commit1)       { Rugged::Commit }
+    let(:commit2)       { Rugged::Commit }
+    let(:commit3)       { Rugged::Commit }
+    let(:revision1)     { VersionControl::Revisions::Committed }
+    let(:revision2)     { VersionControl::Revisions::Committed }
+    let(:revision3)     { VersionControl::Revisions::Committed }
+
+    before do
+      expect(collection).to receive(:rugged_repository).and_return rugged_repo
+      expect(collection).to receive(:_last_rugged_commit).and_return commit1
+
+      expect(Rugged::Walker).to receive(:walk)
+        .with(rugged_repo, show: commit1, simplify: true)
+        .and_return [commit1, commit2, commit3]
+
+      expect(VersionControl::Revisions::Committed)
+        .to receive(:new).with(collection, commit1).and_return revision1
+      expect(VersionControl::Revisions::Committed)
+        .to receive(:new).with(collection, commit2).and_return revision2
+      expect(VersionControl::Revisions::Committed)
+        .to receive(:new).with(collection, commit3).and_return revision3
+    end
+
+    it 'returns [revision3, revision2, revision1]' do
+      is_expected.to eq [revision3, revision2, revision1]
+    end
+
+    it_behaves_like 'caching method call', :all do
+      subject { collection }
+    end
   end
 
   describe '#last' do
@@ -50,6 +87,30 @@ RSpec.describe VersionControl::RevisionCollection, type: :model do
         change { revision_collection.instance_variable_get :@last }
           .from('cached').to(nil)
       )
+    end
+  end
+
+  describe '#_last_rugged_commit', isolated_unit_test: true do
+    subject(:method)    { collection.send :_last_rugged_commit }
+    let(:collection)    { VersionControl::RevisionCollection.new(nil) }
+    let(:rugged_repo)   { instance_double Rugged::Repository }
+    let(:branches)      { instance_double Rugged::BranchCollection }
+    let(:master_branch) { instance_double Rugged::Branch }
+    let(:last_commit)   { instance_double Rugged::Commit }
+
+    before do
+      expect(collection).to receive(:rugged_repository).and_return rugged_repo
+      expect(rugged_repo).to receive(:branches).and_return branches
+      allow(branches).to receive(:[]).with('master').and_return master_branch
+      allow(master_branch).to receive(:target).and_return last_commit
+    end
+
+    it { is_expected.to eq last_commit }
+
+    context 'when master branch does not exist' do
+      before { allow(branches).to receive(:[]).and_return nil }
+
+      it { is_expected.to be nil }
     end
   end
 end

--- a/spec/models/version_control/revision_diff_spec.rb
+++ b/spec/models/version_control/revision_diff_spec.rb
@@ -15,9 +15,12 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
   end
 
   describe 'delegations' do
-    it { should delegate_method(:rugged_repository).to(:repository) }
-    it { should delegate_method(:tree).to(:base).with_prefix(true) }
-    it { should delegate_method(:tree).to(:differentiator).with_prefix(true) }
+    it { is_expected.to delegate_method(:rugged_repository).to(:repository) }
+    it { is_expected.to delegate_method(:tree).to(:base).with_prefix(true) }
+    it do
+      is_expected.to delegate_method(:tree)
+        .to(:differentiator).with_prefix(true)
+    end
   end
 
   describe '#changed_files_as_diffs', isolated_unit_test: true do

--- a/spec/models/version_control/revisions/committed_spec.rb
+++ b/spec/models/version_control/revisions/committed_spec.rb
@@ -32,6 +32,20 @@ RSpec.describe VersionControl::Revisions::Committed, type: :model do
     end
   end
 
+  describe '#author_email', isolated_unit_test: true do
+    subject(:method)  { revision.author_email }
+    let(:revision)    { VersionControl::Revisions::Committed.new(nil, commit) }
+    let(:commit)      { instance_double Rugged::Commit }
+    let(:author)      { { name: 'alice', email: '123', time: Time.zone.now } }
+
+    before do
+      allow(commit).to receive(:oid)
+      allow(commit).to receive(:author).and_return author
+    end
+
+    it { is_expected.to eq '123' }
+  end
+
   describe '#files' do
     subject(:method) { revision.files }
     it do

--- a/spec/models/version_control/revisions/committed_spec.rb
+++ b/spec/models/version_control/revisions/committed_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe VersionControl::Revisions::Committed, type: :model do
     it { is_expected.to eq '123' }
   end
 
+  describe '#created_at', isolated_unit_test: true do
+    subject(:method)  { revision.created_at }
+    let(:revision)    { VersionControl::Revisions::Committed.new(nil, commit) }
+    let(:commit)      { instance_double Rugged::Commit }
+    let(:author)      { { name: 'alice', email: '123', time: time } }
+    let(:time)        { Time.new(2009, 11, 17) }
+
+    before do
+      allow(commit).to receive(:oid)
+      allow(commit).to receive(:author).and_return author
+    end
+
+    it { is_expected.to eq time }
+  end
+
   describe '#files' do
     subject(:method) { revision.files }
     it do

--- a/spec/routing/revision_routing_spec.rb
+++ b/spec/routing/revision_routing_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe 'routes for revisions', type: :routing do
+  it 'has an index route' do
+    expect(profile_project_revisions_path('handle', 'slug'))
+      .to eq '/handle/slug/revisions'
+    expect(get: '/handle/slug/revisions').to(
+      route_to('revisions#index', profile_handle: 'handle',
+                                  project_slug: 'slug')
+    )
+  end
+
   it 'has a new route' do
     expect(new_profile_project_revision_path('handle', 'slug'))
       .to eq '/handle/slug/revisions/new'

--- a/spec/views/projects/show_spec.rb
+++ b/spec/views/projects/show_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe 'projects/show', type: :view do
-  let(:project)     { create(:project) }
-  let(:root_folder) { nil }
+  let(:project)       { create(:project) }
+  let(:root_folder)   { nil }
+  let(:has_revisions) { false }
 
   before do
     assign(:project, project)
     assign(:root_folder, root_folder)
+    assign(:has_revisions, has_revisions)
   end
 
   it 'renders the title of the project' do
@@ -56,6 +58,18 @@ RSpec.describe 'projects/show', type: :view do
       expect(rendered).to have_link(
         'Open in Drive',
         href: view.external_link_for_file(root_folder)
+      )
+    end
+  end
+
+  context 'when at least one revision exists' do
+    let(:has_revisions) { true }
+
+    it 'renders a link to the project revisions' do
+      render
+      expect(rendered).to have_link(
+        'Revisions',
+        href: profile_project_revisions_path(project.owner, project.slug)
       )
     end
   end

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -1,8 +1,19 @@
 # frozen_string_literal: true
 
 RSpec.describe 'revisions/index', type: :view do
-  let(:project)   { create(:project) }
-  let(:revisions) { create_list :revision, 3, repository: project.repository }
+  let(:project)     { create(:project) }
+  let(:repository)  { project.repository }
+  let(:revisions)   { [revision1, revision2, revision3] }
+  let(:revision1) do
+    create :revision, repository: repository, author: authors[0]
+  end
+  let(:revision2) do
+    create :revision, repository: repository, author: authors[1]
+  end
+  let(:revision3) do
+    create :revision, repository: repository, author: authors[2]
+  end
+  let(:authors) { create_list :user, 3 }
 
   before do
     assign(:project, project)
@@ -29,11 +40,11 @@ RSpec.describe 'revisions/index', type: :view do
     end
   end
 
-  it 'renders the author of each revision' do
-    pending 'Not yet implemented'
+  it 'renders the author of each revision with link' do
     render
     authors.each do |author|
-      expect(rendered).to have_css '.revision .author', text: author
+      expect(rendered).to have_css '.revision .author', text: author.name
+      expect(rendered).to have_link author.name, href: profile_path(author)
     end
   end
 

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -18,13 +18,15 @@ RSpec.describe 'revisions/index', type: :view do
   before do
     assign(:project, project)
     assign(:revisions, revisions)
+    controller.request.path_parameters[:profile_handle] = project.owner.to_param
+    controller.request.path_parameters[:project_slug] = project.to_param
   end
 
   it 'renders the title of each revision' do
     render
     revisions.each do |revision|
       expect(rendered).to have_css(
-        ".revision[data-revision-id='#{revision.id}'] .title",
+        ".revision[id='#{revision.id}'] .title",
         text: revision.title
       )
     end
@@ -34,7 +36,7 @@ RSpec.describe 'revisions/index', type: :view do
     render
     revisions.each do |revision|
       expect(rendered).to have_css(
-        ".revision[data-revision-id='#{revision.id}'] .summary",
+        ".revision[id='#{revision.id}'] .summary",
         text: revision.summary
       )
     end
@@ -48,11 +50,22 @@ RSpec.describe 'revisions/index', type: :view do
     end
   end
 
+  it 'renders a timestamp with link for each revision' do
+    render
+    revisions.each do |revision|
+      expect(rendered).to have_link(
+        time_ago_in_words(revision.created_at),
+        href: profile_project_revisions_path(project.owner, project,
+                                             anchor: revision.id)
+      )
+    end
+  end
+
   it 'renders that no files changed' do
     render
     revisions.each do |revision|
       expect(rendered).to have_css(
-        ".revision[data-revision-id='#{revision.id}'] .revision-diff",
+        ".revision[id='#{revision.id}'] .revision-diff",
         text: 'No files changed.'
       )
     end
@@ -77,14 +90,14 @@ RSpec.describe 'revisions/index', type: :view do
       it 'it lists file1 as added' do
         render
         expect(rendered).to have_css(
-          ".revision[data-revision-id='#{revision1.id}'] .file.added",
+          ".revision[id='#{revision1.id}'] .file.added",
           text: 'File1 added to Home'
         )
       end
       it 'it lists folder as added' do
         render
         expect(rendered).to have_css(
-          ".revision[data-revision-id='#{revision1.id}'] .file.added",
+          ".revision[id='#{revision1.id}'] .file.added",
           text: 'Folder added to Home'
         )
       end
@@ -94,14 +107,14 @@ RSpec.describe 'revisions/index', type: :view do
       it 'it lists file2 as added' do
         render
         expect(rendered).to have_css(
-          ".revision[data-revision-id='#{revision2.id}'] .file.added",
+          ".revision[id='#{revision2.id}'] .file.added",
           text: 'File2 added to Home'
         )
       end
       it 'it lists file1 as moved' do
         render
         expect(rendered).to have_css(
-          ".revision[data-revision-id='#{revision2.id}'] .file.moved",
+          ".revision[id='#{revision2.id}'] .file.moved",
           text: 'File1 moved to Home > Folder'
         )
       end
@@ -111,14 +124,14 @@ RSpec.describe 'revisions/index', type: :view do
       it 'it lists file2 as deleted' do
         render
         expect(rendered).to have_css(
-          ".revision[data-revision-id='#{revision3.id}'] .file.deleted",
+          ".revision[id='#{revision3.id}'] .file.deleted",
           text: 'File2 deleted from Home'
         )
       end
       it 'it lists file1 as modified' do
         render
         expect(rendered).to have_css(
-          ".revision[data-revision-id='#{revision3.id}'] .file.modified",
+          ".revision[id='#{revision3.id}'] .file.modified",
           text: 'File1 modified'
         )
       end

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+RSpec.describe 'revisions/index', type: :view do
+  let(:project)   { create(:project) }
+  let(:revisions) { create_list :revision, 3, repository: project.repository }
+
+  before do
+    assign(:project, project)
+    assign(:revisions, revisions)
+  end
+
+  it 'renders the title of each revision' do
+    render
+    revisions.each do |revision|
+      expect(rendered).to have_css(
+        ".revision[data-revision-id='#{revision.id}'] .title",
+        text: revision.title
+      )
+    end
+  end
+
+  it 'renders the summary of each revision' do
+    render
+    revisions.each do |revision|
+      expect(rendered).to have_css(
+        ".revision[data-revision-id='#{revision.id}'] .summary",
+        text: revision.summary
+      )
+    end
+  end
+
+  it 'renders the author of each revision' do
+    pending 'Not yet implemented'
+    render
+    authors.each do |author|
+      expect(rendered).to have_css '.revision .author', text: author
+    end
+  end
+
+  it 'renders that no files changed' do
+    render
+    revisions.each do |revision|
+      expect(rendered).to have_css(
+        ".revision[data-revision-id='#{revision.id}'] .revision-diff",
+        text: 'No files changed.'
+      )
+    end
+  end
+
+  context 'when file diffs exist' do
+    let(:revisions)   { nil }
+    let!(:root)       { create :file, :root, repository: project.repository }
+    let!(:file1)      { create :file, name: 'File1', parent: root }
+    let!(:folder)     { create :file, :folder, name: 'Folder', parent: root }
+    let!(:revision1)  { create :revision, repository: project.repository }
+    let!(:file2)      { create :file, name: 'File2', parent: root }
+    before            { file1.update(parent_id: folder.id) }
+    let!(:revision2)  { create :revision, repository: project.repository }
+    before            { file2.destroy }
+    before            { file1.update(modified_time: Time.zone.now) }
+    let!(:revision3)  { create :revision, repository: project.repository }
+
+    before { assign(:revisions, [revision3, revision2, revision1]) }
+
+    context 'under revision 1' do
+      it 'it lists file1 as added' do
+        render
+        expect(rendered).to have_css(
+          ".revision[data-revision-id='#{revision1.id}'] .file.added",
+          text: 'File1 added to Home'
+        )
+      end
+      it 'it lists folder as added' do
+        render
+        expect(rendered).to have_css(
+          ".revision[data-revision-id='#{revision1.id}'] .file.added",
+          text: 'Folder added to Home'
+        )
+      end
+    end
+
+    context 'under revision 2' do
+      it 'it lists file2 as added' do
+        render
+        expect(rendered).to have_css(
+          ".revision[data-revision-id='#{revision2.id}'] .file.added",
+          text: 'File2 added to Home'
+        )
+      end
+      it 'it lists file1 as moved' do
+        render
+        expect(rendered).to have_css(
+          ".revision[data-revision-id='#{revision2.id}'] .file.moved",
+          text: 'File1 moved to Home > Folder'
+        )
+      end
+    end
+
+    context 'under revision 3' do
+      it 'it lists file2 as deleted' do
+        render
+        expect(rendered).to have_css(
+          ".revision[data-revision-id='#{revision3.id}'] .file.deleted",
+          text: 'File2 deleted from Home'
+        )
+      end
+      it 'it lists file1 as modified' do
+        render
+        expect(rendered).to have_css(
+          ".revision[data-revision-id='#{revision3.id}'] .file.modified",
+          text: 'File1 modified'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Users can see a project's revisions by clicking on the 'Revision' tab in the project navigation. The revision history shows each revision with author, title, summary, timestamp, and file changes.