### PR TITLE
Add file info page

### DIFF
--- a/app/assets/stylesheets/controllers/all.scss
+++ b/app/assets/stylesheets/controllers/all.scss
@@ -1,6 +1,7 @@
 // CSS styles meant to apply to specific controllers
 
 @import 'errors';
+@import 'file_infos';
 @import 'folders';
 @import 'profiles';
 @import 'revisions';

--- a/app/assets/stylesheets/controllers/file_infos.scss
+++ b/app/assets/stylesheets/controllers/file_infos.scss
@@ -1,0 +1,21 @@
+// Styling for ProfilesController
+
+.c-file-infos {
+
+  .page-subheading {
+
+    // the file icon
+    img {
+      height: 1em;
+      position: relative;
+      top: 2px;
+      width: auto;
+    }
+
+    // the actual heading
+    span {
+      display: block;
+      padding-left: 1.3em;
+    }
+  }
+}

--- a/app/assets/stylesheets/controllers/folders.scss
+++ b/app/assets/stylesheets/controllers/folders.scss
@@ -2,8 +2,35 @@
 
 .c-folders {
 
+  // show file info icon on hover
+  .file:hover .info {
+    display: block;
+  }
+
   .file {
     // scss-lint:disable NestingDepth
+
+    .info {
+      height: 24px;
+      margin-left: -24px;
+      width: 24px;
+
+      // on mobile and tablet, hide info icon by default
+      @media #{$large-and-up} {
+        display: none;
+      }
+
+      // black color for icon on hover
+      &:hover {
+        // scss-lint:disable ImportantRule
+        color: color('shades', 'black') !important;
+      }
+    }
+
+    // links should take up full width of column
+    a:not(.info) {
+      display: block;
+    }
 
     // reduce opacity for deleted files
     &.changed.deleted {

--- a/app/assets/stylesheets/controllers/revisions.scss
+++ b/app/assets/stylesheets/controllers/revisions.scss
@@ -1,37 +1,12 @@
-// Styling for ProfilesController
+// Styling for RevisionsController
+// Also shared by FileInfosController
 
-.c-revisions {
+.c-revisions,
+.c-file-infos {
 
   .revision .title {
     line-height: 32px; // match line height of timestamp
-  }
-
-  h3 {
-    position: relative;
-    z-index: 1;
-
-    // Horizontal line/divider behind heading
-    // Adapted from: https://codepen.io/ericrasch/pen/Irlpm
-    &::before {
-      border-top: 1px solid $divider-color;
-      bottom: 0;
-      content: '';
-      left: 0;
-      // positioning must be absolute here, and relative positioning must be
-      // applied to the parent
-      position: absolute;
-      right: 0;
-      top: 50%;
-      width: 100%;
-      z-index: -1;
-    }
-
-    span {
-      // to hide the lines from behind the text, you have to set the background
-      // color the same as the container
-      background: $background-color;
-      padding-right: 25px;
-    }
+    margin-bottom: 15px; // match p tag
   }
 
   .file {

--- a/app/assets/stylesheets/controllers/revisions.scss
+++ b/app/assets/stylesheets/controllers/revisions.scss
@@ -40,6 +40,13 @@
     margin-bottom: 2px;
     margin-top: 2px;
 
+    // for desktop devices, show info button on hover
+    &:hover {
+      .options-on-hover {
+        display: inline-block;
+      }
+    }
+
     .file-icon {
       float: left;
       height: 30px;
@@ -49,7 +56,21 @@
     .file-name {
       display: block;
       line-height: 20px;
+      // allow words to break within if they won't fit on a single line
+      // otherwise
+      overflow-wrap: break-word;
+      // paddding left for the file icon
       padding: 5px 0 5px 35px;
+
+      // padding right for the mobile/tablet file info button
+      @media #{$medium-and-down} {
+        padding-right: 30px;
+      }
+    }
+
+    // hide options by default
+    .options-on-hover {
+      display: none;
     }
 
     a {

--- a/app/assets/stylesheets/shared/buttons.scss
+++ b/app/assets/stylesheets/shared/buttons.scss
@@ -18,3 +18,9 @@
   padding: $button-floating-large-size / 4;
   width: $button-floating-large-size;
 }
+
+// Adjust SVG-based icons in button to be vertically centered
+.btn > i > svg {
+  position: relative;
+  top: 3px;
+}

--- a/app/assets/stylesheets/shared/page-heading.scss
+++ b/app/assets/stylesheets/shared/page-heading.scss
@@ -9,6 +9,10 @@
   // create space between page heading and content
   margin-bottom: 50px;
 
+  // allow breaking words in the middle of the word if the word is too long for
+  // the line
+  overflow-wrap: break-word;
+
   // add vertical spacing within title
   padding: 32px 0;
 
@@ -21,5 +25,34 @@
   // Tabs should add some vertical spacing
   .tabs {
     margin-top: 16px;
+  }
+}
+
+
+// Show a horizontal line/divider behind heading
+// Adapted from: https://codepen.io/ericrasch/pen/Irlpm
+.with-separator {
+  position: relative;
+  z-index: 1;
+
+  &::before {
+    border-top: 1px solid $divider-color;
+    bottom: 0;
+    content: '';
+    left: 0;
+    // positioning must be absolute here, and relative positioning must be
+    // applied to the parent
+    position: absolute;
+    right: 0;
+    top: 50%;
+    width: 100%;
+    z-index: -1;
+  }
+
+  span {
+    // to hide the lines from behind the text, you have to set the background
+    // color the same as the container
+    background: $background-color;
+    padding-right: 25px;
   }
 }

--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Controller for project file infos
+class FileInfosController < ApplicationController
+
+  def index
+
+  end
+end

--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -2,8 +2,57 @@
 
 # Controller for project file infos
 class FileInfosController < ApplicationController
+  include CanSetProjectContext
+  include ProjectLockable
 
-  def index
+  # Execute without lock or render/redirect delay
+  before_action :set_project
 
+  around_action :wrap_action_in_project_lock
+
+  # Execute with lock and render/redirect delay
+  before_action :set_project_context
+  before_action :set_file_id
+  before_action :set_file_versions
+  before_action :set_file
+
+  def index; end
+
+  private
+
+  # Set @file_id from params
+  def set_file_id
+    @file_id = params[:id]
+  end
+
+  # Find file in stage or version history
+  def set_file
+    # Find the file in stage
+    @file = @project.files.find_by_id @file_id
+
+    # Set file to most recent version (unless it's already been set because it
+    # exists in stage)
+    @file ||= @file_versions&.first&.file_is_or_was
+
+    # Raise error if file has not been found in either stage or history
+    raise ActiveRecord::RecordNotFound if @file.nil?
+  end
+
+  # Load file history
+  def set_file_versions
+    # Find past versions of file
+    # TODO@performance: PRELOAD revision diffs, file diffs, and ancestors of
+    # =>                files. Loading those in the view is bad practice and
+    # =>                unnecessary N+1 queries.
+    # TODO: Exclude files that were not 'changed?'
+    # TODO: One day this should be @file.versions or Project.find_file_by_id(id)
+    # =>    which then returns the last version of the file
+    @file_versions =
+      @project.revisions.all_as_diffs.map do |revision_diff|
+        revision_diff.changed_files_as_diffs.find { |diff| diff.id == @file_id }
+      end
+
+    # Eliminate nil values
+    @file_versions.compact!
   end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -5,7 +5,7 @@ module LayoutHelper
   # Return a string containing controller and action name, formatted as
   # 'c-controller_name a-action_name'
   def controller_action_identifier
-    "c-#{controller_name} a-#{action_name}"
+    "c-#{controller_name} a-#{action_name}".tr('_', '-')
   end
 
   # Pick random color scheme

--- a/app/models/version_control/revision_collection.rb
+++ b/app/models/version_control/revision_collection.rb
@@ -25,6 +25,17 @@ module VersionControl
         end
     end
 
+    # Return an array of VersionControl::RevisionDiffs that include diffs
+    # between all revisions in this repository, starting from most recent all
+    # the way to the oldest revision. Each revision will be diffed to its
+    # parent (/previous) revision
+    # rev1 <-> rev2, rev2 <-> rev3, ..., revX <-> nil
+    def all_as_diffs
+      (all + [nil]).each_cons(2).map do |this_revision, previous_revision|
+        this_revision.diff(previous_revision)
+      end
+    end
+
     # Return the last (most recent) revision in this repository
     def last
       return @last if @last

--- a/app/models/version_control/revision_diff.rb
+++ b/app/models/version_control/revision_diff.rb
@@ -4,6 +4,8 @@ module VersionControl
   # The diff (or change) between two revisions in the repository
   class RevisionDiff
     attr_reader :base, :differentiator
+    delegate :id, to: :base, prefix: true
+    delegate :id, to: :differentiator, prefix: true
 
     # Initialize an instance of RevisionDiff given two revisions.
     # The base should be the more current revision, the differentiator the less

--- a/app/models/version_control/revision_diff.rb
+++ b/app/models/version_control/revision_diff.rb
@@ -27,7 +27,9 @@ module VersionControl
         _files_of_blobs_deleted_from_differentiator,
         _files_of_blobs_added_to_base.map(&:id) |
         _files_of_blobs_deleted_from_differentiator.map(&:id)
-      )
+      ).select(&:changed?)
+      # TODO: Eliminate unchanged diffs at the delta level before initializing
+      # =>    files, so we don't need to run #select(&:changed?) at the end.
     end
 
     # Generate a FileDiff between base and differentiator revision for the file

--- a/app/views/file_infos/_file_status.slim
+++ b/app/views/file_infos/_file_status.slim
@@ -1,0 +1,30 @@
+/ render the current file status with links or display that the file has been
+/ deleted
+
+- if current_file_diff.present?
+
+  .row
+    .col.s12.m6
+      = render partial: 'link_to_open_in_drive',
+               locals: { file: current_file_diff.file_is_or_was }
+
+      / Add vertical spacing between the two buttons on mobile devices
+      .spacing.v32px.hide-on-med-and-up
+
+    .col.s12.m6
+      = render partial: 'link_to_parent_folder',
+               locals: { project: project,
+                         file: current_file_diff.file_is_or_was }
+
+  .spacing.v16px
+
+  = render partial: 'new_file_changes',
+           locals: { project: project,
+                     current_file_diff: current_file_diff }
+
+  .spacing.v16px
+
+- else
+
+  i = "This file has been deleted from #{@project.title}."
+  .spacing.v16px

--- a/app/views/file_infos/_file_version_history.slim
+++ b/app/views/file_infos/_file_version_history.slim
@@ -18,4 +18,6 @@ h3.with-separator.no-margin-bottom: span File History
     .divider
 
 - if @file_versions.none?
+
+  .spacing.v16px
   i No previous versions of this file exist.

--- a/app/views/file_infos/_file_version_history.slim
+++ b/app/views/file_infos/_file_version_history.slim
@@ -1,0 +1,21 @@
+/ render list of revisions that affected the file
+
+h3.with-separator.no-margin-bottom: span File History
+
+- @file_versions.each_with_index do |version, index|
+
+  - revision = version.revision_diff.base
+
+  / TODO: BUG: The call to profiles below is triggering an N+1 query. Needs fixing!
+  = render partial: 'revisions/revision_with_diff',
+           object: revision,
+           locals: { project: project,
+                     profile: Profiles::User.find_by_id(revision.author_email),
+                     file_diffs: [version],
+                     show_link_to_file_info: false }
+
+  - if index != (@file_versions.count - 1)
+    .divider
+
+- if @file_versions.none?
+  i No previous versions of this file exist.

--- a/app/views/file_infos/_link_to_open_in_drive.slim
+++ b/app/views/file_infos/_link_to_open_in_drive.slim
@@ -1,0 +1,9 @@
+/ render a link to the file on Google Drive
+
+= link_to external_link_for_file(file),
+          class: 'btn btn-large primary-color primary-color-text',
+          target: '_blank' do
+  i.left.material_icons
+    svg style="width:24px;height:24px" viewBox="0 0 24 24"
+      path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+  | Open in Drive

--- a/app/views/file_infos/_link_to_parent_folder.slim
+++ b/app/views/file_infos/_link_to_parent_folder.slim
@@ -1,0 +1,10 @@
+/ render a button to the file's parent folder
+
+/ TODO: Optimize link to direct to clean root folder path ('files') if parent is
+/       root
+= link_to profile_project_folder_path(project.owner, project, file.parent_id),
+          class: 'btn btn-large primary-color primary-color-text' do
+  i.left.material_icons
+    svg style="width:24px;height:24px" viewBox="0 0 24 24"
+      path fill="currentColor" d="M10,4H4C2.89,4 2,4.89 2,6V18A2,2 0 0,0 4,20H20A2,2 0 0,0 22,18V8C22,6.89 21.1,6 20,6H12L10,4Z"
+  | Open Parent Folder

--- a/app/views/file_infos/_new_file_changes.slim
+++ b/app/views/file_infos/_new_file_changes.slim
@@ -7,7 +7,8 @@ h3.with-separator: span New Changes (uncommitted)
   = render partial: 'revisions/revision_diff',
            locals: { project: project,
                      file_diffs: [current_file_diff],
-                     show_link_to_file_info: false }
+                     show_link_to_file_info: false,
+                     all_links_in_new_tab: false }
 
 
 - else

--- a/app/views/file_infos/_new_file_changes.slim
+++ b/app/views/file_infos/_new_file_changes.slim
@@ -1,0 +1,14 @@
+/ render list of current file changes, if any
+
+h3.with-separator: span New Changes (uncommitted)
+
+- if current_file_diff.changes.any?
+
+  = render partial: 'revisions/revision_diff',
+           locals: { project: project,
+                     file_diffs: [current_file_diff],
+                     show_link_to_file_info: false }
+
+
+- else
+  i No changes have been made to this file since the last revision.

--- a/app/views/file_infos/index.slim
+++ b/app/views/file_infos/index.slim
@@ -2,6 +2,25 @@
   .container
     .row.no-margin-bottom
       .col.s12
-        h2 File Info
+        h2
+          = image_tag icon_for_file(@file),
+                      alt: 'File icon',
+                      size: '56',
+                      class: 'img-responsive left'
+          span = @file.name
 
 .container
+
+  .row
+    .col.s12.m6
+      = render partial: 'link_to_open_in_drive', locals: { file: @file }
+
+      / Add vertical spacing between the two buttons on mobile devices
+      .spacing.v32px.hide-on-med-and-up
+
+    .col.s12.m6
+      = render partial: 'link_to_parent_folder',
+               locals: { project: @project, file: @file }
+
+
+  .spacing.v48px

--- a/app/views/file_infos/index.slim
+++ b/app/views/file_infos/index.slim
@@ -22,5 +22,9 @@
       = render partial: 'link_to_parent_folder',
                locals: { project: @project, file: @file }
 
+  .spacing.v32px
+
+  = render partial: 'file_version_history',
+           locals: { project: @project, file_versions: @file_versions }
 
   .spacing.v48px

--- a/app/views/file_infos/index.slim
+++ b/app/views/file_infos/index.slim
@@ -11,18 +11,9 @@
 
 .container
 
-  .row
-    .col.s12.m6
-      = render partial: 'link_to_open_in_drive', locals: { file: @file }
-
-      / Add vertical spacing between the two buttons on mobile devices
-      .spacing.v32px.hide-on-med-and-up
-
-    .col.s12.m6
-      = render partial: 'link_to_parent_folder',
-               locals: { project: @project, file: @file }
-
-  .spacing.v32px
+  = render partial: 'file_status',
+           locals: { current_file_diff: @current_file_diff,
+                     project: @project }
 
   = render partial: 'file_version_history',
            locals: { project: @project, file_versions: @file_versions }

--- a/app/views/file_infos/index.slim
+++ b/app/views/file_infos/index.slim
@@ -1,0 +1,7 @@
+.page-subheading.gray.lighten-3
+  .container
+    .row.no-margin-bottom
+      .col.s12
+        h2 File Info
+
+.container

--- a/app/views/folders/_file_diff.slim
+++ b/app/views/folders/_file_diff.slim
@@ -1,9 +1,13 @@
 / render a single file with diff/change indicator
 
-= link_to_file(file_diff.file_is_or_was, project) do
+div.file[class=type_of_file(file_diff.file_is_or_was)
+         class=html_class_for_file_diff_changes(file_diff.changes)]
 
-  div.file[class=type_of_file(file_diff.file_is_or_was)
-           class=html_class_for_file_diff_changes(file_diff.changes)]
+  = render partial: 'link_to_file_info',
+           locals: { file_id: file_diff.id, project: project }
+
+  = link_to_file(file_diff.file_is_or_was, project) do
+
 
     div.indicators
       = render partial: 'file_diff_indicator',

--- a/app/views/folders/_link_to_file_info.slim
+++ b/app/views/folders/_link_to_file_info.slim
@@ -1,0 +1,5 @@
+/ Renders the link icon to the file's info page
+= link_to profile_project_file_infos_path(project.owner, project, file_id),
+          class: 'info right gray-text' do
+  svg style="width:24px;height:24px" viewBox="0 0 24 24"
+    path fill="currentColor" d="M11,9H13V7H11M12,20C7.59,20 4,16.41 4,12C4,7.59 7.59,4 12,4C16.41,4 20,7.59 20,12C20,16.41 16.41,20 12,20M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M11,17H13V11H11V17Z"

--- a/app/views/layouts/file_infos.slim
+++ b/app/views/layouts/file_infos.slim
@@ -1,0 +1,6 @@
+= render partial: 'projects/head', object: @project, as: :project,
+         locals: { active_tab: nil }
+
+= yield
+
+= parent_layout 'application'

--- a/app/views/revisions/_file_diff.slim
+++ b/app/views/revisions/_file_diff.slim
@@ -1,7 +1,8 @@
 / render one entry for every change to the file (i.e. if a document was modified
 / and moved, it will be shown separately on two consecutive lines)
-= render partial: 'file_diff_change',
+= render partial: 'revisions/file_diff_change',
          collection: file_diff.changes,
          locals: { file_diff: file_diff,
                    ancestors: file_diff.ancestors_of_file,
-                   project: project }
+                   project: project,
+                   show_link_to_file_info: show_link_to_file_info }

--- a/app/views/revisions/_file_diff.slim
+++ b/app/views/revisions/_file_diff.slim
@@ -5,4 +5,5 @@
          locals: { file_diff: file_diff,
                    ancestors: file_diff.ancestors_of_file,
                    project: project,
-                   show_link_to_file_info: show_link_to_file_info }
+                   show_link_to_file_info: show_link_to_file_info,
+                   all_links_in_new_tab: all_links_in_new_tab }

--- a/app/views/revisions/_file_diff_change.slim
+++ b/app/views/revisions/_file_diff_change.slim
@@ -1,3 +1,5 @@
+/ Renders a single file change of a file
+
 div.file[class=type_of_file(file_diff.file_is_or_was)
          class=file_diff_change]
 
@@ -6,8 +8,9 @@ div.file[class=type_of_file(file_diff.file_is_or_was)
              size: '30',
              class: 'img-responsive file-icon'
 
-  = render partial: 'file_diff_change_text',
+  = render partial: 'revisions/file_diff_change_text',
            locals: { file_diff_change: file_diff_change,
                      file_diff: file_diff,
                      ancestors: ancestors,
-                     project: project }
+                     project: project,
+                     show_link_to_file_info: show_link_to_file_info }

--- a/app/views/revisions/_file_diff_change.slim
+++ b/app/views/revisions/_file_diff_change.slim
@@ -13,4 +13,5 @@ div.file[class=type_of_file(file_diff.file_is_or_was)
                      file_diff: file_diff,
                      ancestors: ancestors,
                      project: project,
-                     show_link_to_file_info: show_link_to_file_info }
+                     show_link_to_file_info: show_link_to_file_info,
+                     all_links_in_new_tab: all_links_in_new_tab }

--- a/app/views/revisions/_file_diff_change_text.slim
+++ b/app/views/revisions/_file_diff_change_text.slim
@@ -3,17 +3,21 @@
 - moved     = (file_diff_change == :moved)
 - deleted   = (file_diff_change == :deleted)
 
+- link_options = ( all_links_in_new_tab ? { target: '_blank' } : {} )
+
 - if show_link_to_file_info
   = render partial: 'revisions/link_to_file_info',
-           locals: { file_id: file_diff.id, project: project,
-                     device: :mobile_and_tablet }
+           locals: { file_id: file_diff.id,
+                     project: project,
+                     device: :mobile_and_tablet,
+                     link_options: link_options }
 
 span.file-name[class=text_color_for_file_diff_change(file_diff_change)]
 
   span.name-and-description
     / print: filename in bold
     b
-      = link_to_file(file_diff.file_is_or_was, project, target: '_blank') do
+      = link_to_file(file_diff.file_is_or_was, project, link_options) do
         = file_diff.name
 
     / print: added/modified/moved/deleted
@@ -32,4 +36,7 @@ span.file-name[class=text_color_for_file_diff_change(file_diff_change)]
 
   - if show_link_to_file_info
     = render partial: 'revisions/link_to_file_info',
-             locals: { file_id: file_diff.id, project: project, device: :desktop }
+             locals: { file_id: file_diff.id,
+                       project: project,
+                       device: :desktop,
+                       link_options: link_options }

--- a/app/views/revisions/_file_diff_change_text.slim
+++ b/app/views/revisions/_file_diff_change_text.slim
@@ -3,24 +3,31 @@
 - moved     = (file_diff_change == :moved)
 - deleted   = (file_diff_change == :deleted)
 
+= render partial: 'link_to_file_info',
+         locals: { file_id: file_diff.id, project: project,
+                   device: :mobile_and_tablet }
 
 span.file-name[class=text_color_for_file_diff_change(file_diff_change)]
 
-  / print: filename in bold
-  b
-    = link_to_file(file_diff.file_is_or_was, project, target: '_blank') do
-      = file_diff.name
+  span.name-and-description
+    / print: filename in bold
+    b
+      = link_to_file(file_diff.file_is_or_was, project, target: '_blank') do
+        = file_diff.name
 
-  / print: added/modified/moved/deleted
-  =< file_diff_change
+    / print: added/modified/moved/deleted
+    =< file_diff_change
 
-  / print: ancestor path
-  - if moved || added || deleted
-    / Drop root level entry from path and replace with 'Home'
-    - ancestor_path = \
-        ancestors.reverse.map(&:name).drop(1).prepend('Home').join(' > ')
+    / print: ancestor path
+    - if moved || added || deleted
+      / Drop root level entry from path and replace with 'Home'
+      - ancestor_path = \
+          ancestors.reverse.map(&:name).drop(1).prepend('Home').join(' > ')
 
-    - if moved || added
-      =< "to #{ancestor_path}"
-    - else
-      =< "from #{ancestor_path}"
+      - if moved || added
+        =< "to #{ancestor_path}"
+      - else
+        =< "from #{ancestor_path}"
+
+  = render partial: 'link_to_file_info',
+           locals: { file_id: file_diff.id, project: project, device: :desktop }

--- a/app/views/revisions/_file_diff_change_text.slim
+++ b/app/views/revisions/_file_diff_change_text.slim
@@ -3,9 +3,10 @@
 - moved     = (file_diff_change == :moved)
 - deleted   = (file_diff_change == :deleted)
 
-= render partial: 'link_to_file_info',
-         locals: { file_id: file_diff.id, project: project,
-                   device: :mobile_and_tablet }
+- if show_link_to_file_info
+  = render partial: 'revisions/link_to_file_info',
+           locals: { file_id: file_diff.id, project: project,
+                     device: :mobile_and_tablet }
 
 span.file-name[class=text_color_for_file_diff_change(file_diff_change)]
 
@@ -29,5 +30,6 @@ span.file-name[class=text_color_for_file_diff_change(file_diff_change)]
       - else
         =< "from #{ancestor_path}"
 
-  = render partial: 'link_to_file_info',
-           locals: { file_id: file_diff.id, project: project, device: :desktop }
+  - if show_link_to_file_info
+    = render partial: 'revisions/link_to_file_info',
+             locals: { file_id: file_diff.id, project: project, device: :desktop }

--- a/app/views/revisions/_link_to_file_info.slim
+++ b/app/views/revisions/_link_to_file_info.slim
@@ -1,0 +1,16 @@
+/ Renders the link icon to the file's info page
+- link = profile_project_file_infos_path(project.owner, project, file_id)
+
+/ for touch devices, always display the info button
+- if device == :mobile_and_tablet
+  span.right.hide-on-large-only.grey-text
+    = link_to link, class: 'info' do
+      svg style="width:24px;height:24px" viewBox="0 0 24 24"
+        path fill="currentColor" d="M16,12A2,2 0 0,1 18,10A2,2 0 0,1 20,12A2,2 0 0,1 18,14A2,2 0 0,1 16,12M10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12M4,12A2,2 0 0,1 6,10A2,2 0 0,1 8,12A2,2 0 0,1 6,14A2,2 0 0,1 4,12Z"
+
+/ for desktop devices, display info button hover only
+- elsif device == :desktop
+  span.options-on-hover.hide-on-med-and-down<
+    span.gray-text
+      | &middot;
+    =< link_to 'More', link, class: 'info gray-text'

--- a/app/views/revisions/_link_to_file_info.slim
+++ b/app/views/revisions/_link_to_file_info.slim
@@ -4,7 +4,7 @@
 / for touch devices, always display the info button
 - if device == :mobile_and_tablet
   span.right.hide-on-large-only.grey-text
-    = link_to link, class: 'info' do
+    = link_to link, link_options, class: 'info' do
       svg style="width:24px;height:24px" viewBox="0 0 24 24"
         path fill="currentColor" d="M16,12A2,2 0 0,1 18,10A2,2 0 0,1 20,12A2,2 0 0,1 18,14A2,2 0 0,1 16,12M10,12A2,2 0 0,1 12,10A2,2 0 0,1 14,12A2,2 0 0,1 12,14A2,2 0 0,1 10,12M4,12A2,2 0 0,1 6,10A2,2 0 0,1 8,12A2,2 0 0,1 6,14A2,2 0 0,1 4,12Z"
 
@@ -13,4 +13,4 @@
   span.options-on-hover.hide-on-med-and-down<
     span.gray-text
       | &middot;
-    =< link_to 'More', link, class: 'info gray-text'
+    =< link_to 'More', link, link_options.merge(class: 'info gray-text')

--- a/app/views/revisions/_revision.slim
+++ b/app/views/revisions/_revision.slim
@@ -1,7 +1,9 @@
 .metadata
-  h5.title
-    = render partial: 'revision_timestamp',
-             locals: { revision: revision, device: :desktop }
+  h5.title.no-margin-top
+    = render partial: 'revisions/revision_timestamp',
+             locals: { project: project, revision: revision, device: :desktop }
     b = revision.title
-  .summary
-    = simple_format html_escape(revision.summary)
+
+  - if revision.summary.present?
+    .summary
+      = simple_format html_escape(revision.summary)

--- a/app/views/revisions/_revision_diff.slim
+++ b/app/views/revisions/_revision_diff.slim
@@ -5,6 +5,7 @@
     = render partial: 'revisions/file_diff',
              collection: sort_file_diffs!(file_diffs),
              locals: { project: project,
-                       show_link_to_file_info: show_link_to_file_info }
+                       show_link_to_file_info: show_link_to_file_info,
+                       all_links_in_new_tab: all_links_in_new_tab }
   - else
     i No files changed.

--- a/app/views/revisions/_revision_diff.slim
+++ b/app/views/revisions/_revision_diff.slim
@@ -1,9 +1,10 @@
-/ render file changes
-/ TODO: Is this the right place for sorting?
-- file_diffs = revision_diff.changed_files_as_diffs.select(&:changed?)
-- sort_file_diffs! file_diffs
+/ Renders the changes of a file (file diffs)
 
 .revision-diff
-  = render(partial: 'file_diff',
-           collection: file_diffs,
-           locals: { project: project }) || '<i>No files changed.</i>'.html_safe
+  - if file_diffs.any?
+    = render partial: 'revisions/file_diff',
+             collection: sort_file_diffs!(file_diffs),
+             locals: { project: project,
+                       show_link_to_file_info: show_link_to_file_info }
+  - else
+    i No files changed.

--- a/app/views/revisions/_revision_timestamp.slim
+++ b/app/views/revisions/_revision_timestamp.slim
@@ -6,7 +6,8 @@
   - class_tag = 'hide-on-med-and-up'
   - is_slim   = true
 
-= link_to({ anchor: revision.id }, class: class_tag ) do
+= link_to profile_project_revisions_path(project.owner, project, anchor: revision.id),
+          class: class_tag do
   span.chip.right[class=('slim' if is_slim)]
     => time_ago_in_words(revision.created_at)
     | ago

--- a/app/views/revisions/_revision_with_diff.slim
+++ b/app/views/revisions/_revision_with_diff.slim
@@ -24,4 +24,5 @@
     = render partial: 'revisions/revision_diff',
              locals: { file_diffs: file_diffs,
                        project: project,
-                       show_link_to_file_info: show_link_to_file_info }
+                       show_link_to_file_info: show_link_to_file_info,
+                       all_links_in_new_tab: false }

--- a/app/views/revisions/_revision_with_diff.slim
+++ b/app/views/revisions/_revision_with_diff.slim
@@ -1,0 +1,27 @@
+/ render a single revision with file diff
+
+.row.revision id=revision_with_diff.id
+
+  .spacing.v8px
+
+  = render partial: 'revisions/revision_timestamp',
+           locals: { project: project,
+                     revision: revision_with_diff,
+                     device: :mobile }
+
+  .spacing.v8px
+
+
+  .col.l2.m3.s12.center-align
+    = render partial: 'profiles/profile',
+             object: profile
+
+  .col.l10.m9.s12
+    = render partial: 'revisions/revision',
+             object: revision_with_diff,
+             locals: { project: project }
+
+    = render partial: 'revisions/revision_diff',
+             locals: { file_diffs: file_diffs,
+                       project: project,
+                       show_link_to_file_info: show_link_to_file_info }

--- a/app/views/revisions/index.slim
+++ b/app/views/revisions/index.slim
@@ -1,32 +1,22 @@
 .container
 
-  .spacing.v16px
+  .spacing.v32px
 
   - (@revisions + [nil]).each_cons(2) do |this_revision, previous_revision|
-    .row.revision id=this_revision.id
 
-      .spacing.v8px
+    - revision_diff = this_revision.diff(previous_revision)
 
-      = render partial: 'revision_timestamp',
-               locals: { revision: this_revision, device: :mobile }
-
-      .spacing.v8px
-
-
-      .col.l2.m3.s12.center-align
-        / TODO: BUG: This is triggering an N+1 query. Needs fixing!
-        = render partial: 'profiles/profile',
-                 object: Profiles::User.find_by_id(this_revision.author_email)
-
-      .col.l10.m9.s12
-        = render partial: 'revision', object: this_revision
-
-        / TODO: this is probably not the right place to generate a diff
-        = render partial: 'revision_diff',
-                 object: this_revision.diff(previous_revision),
-                 locals: { project: @project }
+    / TODO: BUG: The call to profiles below is triggering an N+1 query. Needs fixing!
+    = render partial: 'revision_with_diff',
+             object: this_revision,
+             locals: { project: @project,
+                       profile: Profiles::User.find_by_id(this_revision.author_email),
+                       file_diffs: revision_diff.changed_files_as_diffs,
+                       show_link_to_file_info: true }
 
     - if previous_revision.present?
+      .spacing.v16px
       .divider
+      .spacing.v16px
 
 .spacing.v48px

--- a/app/views/revisions/new.slim
+++ b/app/views/revisions/new.slim
@@ -40,8 +40,10 @@
 
     h3: span Review Changes
     // TODO: This is probably not the right place to generate a diff
+    - revision_diff = @revision.diff(@project.repository.revisions.last)
     = render partial: 'revision_diff',
-             object: @revision.diff(@project.repository.revisions.last),
-             locals: { project: @project }
+             locals: { project: @project,
+                       file_diffs: revision_diff.changed_files_as_diffs,
+                       show_link_to_file_info: true }
 
     .spacing.v48px

--- a/app/views/revisions/new.slim
+++ b/app/views/revisions/new.slim
@@ -44,6 +44,7 @@
     = render partial: 'revision_diff',
              locals: { project: @project,
                        file_diffs: revision_diff.changed_files_as_diffs,
-                       show_link_to_file_info: true }
+                       show_link_to_file_info: true,
+                       all_links_in_new_tab: true }
 
     .spacing.v48px

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,10 +57,13 @@ Rails.application.routes.draw do
               path: '/', except: %i[index new create], param: :slug do
       get  'setup'  => 'projects#setup',  on: :member
       post 'import' => 'projects#import', on: :member
-      # Route for folders
+      # Routes for folders
       get 'files' => 'folders#root', as: :root_folder
       resources :folders, only: :show
+      # Routes for revisions
       resources :revisions, only: %i[index new create]
+      # Routes for file infos
+      resources :file_infos, path: 'files/:id/info', only: :index
     end
   end
 

--- a/spec/controllers/file_info_controller_spec.rb
+++ b/spec/controllers/file_info_controller_spec.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.describe FileInfosController, type: :controller do
-
-end

--- a/spec/controllers/file_info_controller_spec.rb
+++ b/spec/controllers/file_info_controller_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+RSpec.describe FileInfosController, type: :controller do
+
+end

--- a/spec/controllers/file_infos_controller_spec.rb
+++ b/spec/controllers/file_infos_controller_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'controllers/shared_examples/a_repository_locking_action.rb'
+require 'controllers/shared_examples/raise_404_if_non_existent.rb'
+require 'controllers/shared_examples/setting_project_context.rb'
+
+RSpec.describe FileInfosController, type: :controller do
+  let!(:file)     { create :file, parent: root }
+  let(:root)      { create :file, :root, repository: project.repository }
+  let!(:project)  { create :project }
+  let(:default_params) do
+    {
+      profile_handle: project.owner.to_param,
+      project_slug:   project.slug,
+      id:             file.id
+    }
+  end
+
+  describe 'GET #index' do
+    let(:params)      { default_params }
+    let(:run_request) { get :index, params: params }
+
+    include_examples 'raise 404 if non-existent', Profiles::Base
+    include_examples 'raise 404 if non-existent', Project
+    it_should_behave_like 'raise 404 if non-existent', nil do
+      # when file does not exist and never has
+      before { default_params[:id] = 'some-nonexistent-id' }
+    end
+
+    it_should_behave_like 'a repository locking action'
+    it_should_behave_like 'setting project context'
+
+    it 'returns http success' do
+      run_request
+      expect(response).to have_http_status :success
+    end
+  end
+end

--- a/spec/features/file_info_spec.rb
+++ b/spec/features/file_info_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+feature 'File Info' do
+  scenario 'User can see file info' do
+    # given there is a project
+    project = create :project
+    # with a committed file
+    root = create :file, :root, repository: project.repository
+    file = create :file, name: 'File1', parent: root
+    first_revision = create :revision, repository: project.repository
+
+    # when I visit the project page
+    visit "#{project.owner.to_param}/#{project.to_param}"
+    # and click on Files
+    click_on 'Files'
+    # and click on the file info button
+    find('.file .info').click
+
+    # then I should be on the file's info page
+    expect(page).to have_current_path(
+      "/#{project.owner.to_param}/#{project.to_param}/files/#{file.id}/info"
+    )
+    # and see one revision
+    expect(page.find_all('.revision .metadata .title b').map(&:text))
+      .to eq [first_revision].map(&:title)
+    # and see A file change entry for the file
+    expect(page.find_all('.revision-diff').map(&:text)).to eq(
+      ['File1 added to Home']
+    )
+  end
+
+  scenario 'User can see file info for newly added files' do
+    # given there is a project
+    project = create :project
+    # with a newly added file
+    root = create :file, :root, repository: project.repository
+    file = create :file, name: 'File1', parent: root
+
+    # when I visit the project page
+    visit "#{project.owner.to_param}/#{project.to_param}"
+    # and click on Files
+    click_on 'Files'
+    # and click on the file info button
+    find('.file .info').click
+
+    # then I should be on the file's info page
+    expect(page).to have_current_path(
+      "/#{project.owner.to_param}/#{project.to_param}/files/#{file.id}/info"
+    )
+    # and see no revisions
+    expect(page).to have_text 'No previous versions'
+  end
+
+  scenario 'User can see file info of deleted files' do
+    # given there is a project
+    project = create :project
+    # with a committed file that has been deleted
+    root = create :file, :root, repository: project.repository
+    file = create :file, name: 'File1', parent: root
+    first_revision = create :revision, repository: project.repository
+    file.destroy
+    second_revision = create :revision, repository: project.repository
+
+    # when I visit the project page
+    visit "#{project.owner.to_param}/#{project.to_param}"
+    # and click on Revisions
+    click_on 'Revisions'
+    # and click on the file info button
+    within ".revision[id='#{second_revision.id}']" do
+      click_on 'More'
+    end
+
+    # then I should be on the file's info page
+    expect(page).to have_current_path(
+      "/#{project.owner.to_param}/#{project.to_param}/files/#{file.id}/info"
+    )
+    # and see two revisions
+    expect(page.find_all('.revision .metadata .title b').map(&:text))
+      .to eq [second_revision, first_revision].map(&:title)
+    # and see A file change entry for the file
+    expect(page.find_all('.revision-diff').map(&:text)).to eq(
+      ['File1 deleted from Home', 'File1 added to Home']
+    )
+  end
+end

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -33,7 +33,7 @@ feature 'Revision' do
     expect(page.find_all('.revision .profile').map(&:text))
       .to eq [users.last.name, users.second.name, users.first.name]
     # and see file changes for each revision
-    expect(page.find_all('.revision-diff').map(&:text)).to eq(
+    expect(page.find_all('.revision .name-and-description').map(&:text)).to eq(
       ['File1 deleted from Home', 'File1 modified', 'File1 added to Home']
     )
   end

--- a/spec/helpers/layout_helper_spec.rb
+++ b/spec/helpers/layout_helper_spec.rb
@@ -19,6 +19,17 @@ RSpec.describe LayoutHelper, type: :helper do
     it 'includes the action name with a- prefix' do
       expect(helper.controller_action_identifier).to include 'a-create'
     end
+
+    context 'when controller_name or action_name includes hyphens' do
+      before do
+        allow(controller).to receive(:controller_name).and_return('a_b_c')
+        allow(controller).to receive(:action_name).and_return('d_e_f')
+      end
+
+      it 'replaces them with dashes' do
+        expect(helper.controller_action_identifier).to eq 'c-a-b-c a-d-e-f'
+      end
+    end
   end
 
   describe '#color_scheme' do

--- a/spec/integrations/version_control/revision_collection_spec.rb
+++ b/spec/integrations/version_control/revision_collection_spec.rb
@@ -30,4 +30,37 @@ RSpec.describe VersionControl::RevisionCollection, type: :model do
       it { is_expected.to eq [] }
     end
   end
+
+  describe '#all_as_diffs' do
+    subject(:method)        { revision_collection.all_as_diffs }
+    let!(:oldest_revision)  { create :revision, repository: repository }
+    let!(:second_revision)  { create :revision, repository: repository }
+    let!(:newest_revision)  { create :revision, repository: repository }
+
+    it 'returns three revision diffs' do
+      expect(method).to be_an Array
+      expect(method.map(&:class).uniq).to eq [VersionControl::RevisionDiff]
+    end
+
+    it 'returns an array with diff between newest and second revision' do
+      expect(method.first).to have_attributes(
+        base_id: newest_revision.id,
+        differentiator_id: second_revision.id
+      )
+    end
+
+    it 'returns an array with diff between second and oldest revision' do
+      expect(method.first).to have_attributes(
+        base_id: newest_revision.id,
+        differentiator_id: second_revision.id
+      )
+    end
+
+    it 'returns an array with diff between oldest revision and nil' do
+      expect(method.first).to have_attributes(
+        base_id: newest_revision.id,
+        differentiator_id: second_revision.id
+      )
+    end
+  end
 end

--- a/spec/integrations/version_control/revision_diff_spec.rb
+++ b/spec/integrations/version_control/revision_diff_spec.rb
@@ -87,14 +87,19 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
       it { expect(method.map(&:id)).not_to include root.id }
     end
 
-    xcontext 'when parent is moved' do
+    context 'when folder with files is moved' do
+      let!(:child)        { create :file, parent: folder }
+      let!(:other_folder) { create :file, :folder, parent: root }
+      before              { create :revision, repository: repository }
+      # move the folder
+      before              { folder.update(parent_id: other_folder.id) }
 
-      it 'includes the parent' do
-
+      it 'includes the folder' do
+        expect(method.map(&:id)).to include folder.id
       end
 
-      it 'does not include the children' do
-
+      it 'does not include the child file' do
+        expect(method.map(&:id)).not_to include child.id
       end
     end
   end

--- a/spec/integrations/version_control/revision_diff_spec.rb
+++ b/spec/integrations/version_control/revision_diff_spec.rb
@@ -86,5 +86,16 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
 
       it { expect(method.map(&:id)).not_to include root.id }
     end
+
+    xcontext 'when parent is moved' do
+
+      it 'includes the parent' do
+
+      end
+
+      it 'does not include the children' do
+
+      end
+    end
   end
 end

--- a/spec/models/version_control/revision_diff_spec.rb
+++ b/spec/models/version_control/revision_diff_spec.rb
@@ -47,6 +47,12 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
     end
 
     before do
+      expect(diff1).to receive(:changed?).and_return false
+      expect(diff2).to receive(:changed?).and_return true
+      expect(diff3).to receive(:changed?).and_return true
+    end
+
+    before do
       expect(diff).to receive(:_files_of_blobs_added_to_base)
         .exactly(2).times.and_return [file1, file2]
       expect(diff).to receive(:_files_of_blobs_deleted_from_differentiator)
@@ -56,8 +62,8 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
         .and_return [diff1, diff2, diff3]
     end
 
-    it 'returns [diff1, diff2, diff3]' do
-      is_expected.to eq [diff1, diff2, diff3]
+    it 'returns [diff2, diff3]' do
+      is_expected.to eq [diff2, diff3]
     end
   end
 
@@ -406,32 +412,20 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
 
   describe '#_rugged_deltas', isolated_unit_test: true do
     subject(:method)  { diff.send :_rugged_deltas }
-    let(:rugged_repo) { instance_double Rugged::Repository }
-    # let(:base)        { instance_double VersionControl::Revisions::Committed }
-    let(:base_tree)   { instance_double Rugged::Tree }
-    let(:differentiator_tree) { instance_double Rugged::Tree }
-    let(:rugged_diff)         { instance_double Rugged::Diff }
-    let(:delta1)              { instance_double Rugged::Diff::Delta }
-    let(:delta2)              { instance_double Rugged::Diff::Delta }
+    let(:rugged_diff) { instance_double Rugged::Diff }
+    let(:deltas)      { %w[delta1 delta1] }
 
     before do
-      expect(diff).to receive(:rugged_repository).and_return rugged_repo
-      expect(diff).to receive(:base_tree).and_return base_tree
+      expect(diff).to receive(:rugged_repository).and_return 'rugged_repo'
+      expect(diff).to receive(:base_tree).and_return 'base_tree'
       expect(diff).to receive(:differentiator_tree)
-        .and_return differentiator_tree
-      # expect(base).to receive(:tree).and_return base_tree
+        .and_return 'differentiator_tree'
       expect(Rugged::Tree).to receive(:diff)
-        .with(rugged_repo, differentiator_tree, base_tree)
+        .with('rugged_repo', 'differentiator_tree', 'base_tree')
         .and_return rugged_diff
-      expect(rugged_diff).to receive(:deltas).and_return [delta1, delta2]
+      expect(rugged_diff).to receive(:deltas).and_return deltas
     end
 
-    it 'returns [delta1, delta2]' do
-      is_expected.to eq [delta1, delta2]
-    end
-
-    it_behaves_like 'caching method call', :_rugged_deltas do
-      subject { diff }
-    end
+    it { is_expected.to eq deltas }
   end
 end

--- a/spec/models/version_control/revision_diff_spec.rb
+++ b/spec/models/version_control/revision_diff_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
   describe 'delegations' do
     it { is_expected.to delegate_method(:rugged_repository).to(:repository) }
     it { is_expected.to delegate_method(:tree).to(:base).with_prefix(true) }
+    it { is_expected.to delegate_method(:id).to(:base).with_prefix(true) }
+    it do
+      is_expected.to delegate_method(:id).to(:differentiator).with_prefix(true)
+    end
     it do
       is_expected.to delegate_method(:tree)
         .to(:differentiator).with_prefix(true)

--- a/spec/routing/file_info_routing_spec.rb
+++ b/spec/routing/file_info_routing_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+RSpec.describe 'routes for file infos', type: :routing do
+  it 'has an index route' do
+    expect(profile_project_file_infos_path('handle', 'slug', 'file-id'))
+      .to eq '/handle/slug/files/file-id/info'
+    expect(get: '/handle/slug/files/file-id/info').to(
+      route_to('file_infos#index',
+               profile_handle: 'handle',
+               project_slug: 'slug',
+               id: 'file-id')
+    )
+  end
+end

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+RSpec.describe 'file_infos/index', type: :view do
+  let(:project)       { build_stubbed :project }
+  let(:file)          { build :file }
+  let(:file_versions) { [] }
+
+  before do
+    assign(:project, project)
+    assign(:file, file)
+    assign(:file_versions, file_versions)
+  end
+
+  it 'renders the file icon' do
+    render
+    icon = view.icon_for_file(file)
+    expect(rendered).to have_css "h2 img[src='#{view.asset_path(icon)}']"
+  end
+
+  it 'renders the file name' do
+    render
+    expect(rendered).to have_css 'h2', text: file.name
+  end
+
+  it 'has a link to the file on Google Drive' do
+    render
+    expect(rendered).to have_link 'Open in Drive',
+                                  href: view.external_link_for_file(file)
+  end
+
+  it 'has a link to the parent folder' do
+    render
+    link = profile_project_folder_path(project.owner, project, file.parent_id)
+    expect(rendered).to have_link 'Open Parent Folder', href: link
+  end
+
+  xcontext 'when file is and has been deleted' do
+    it 'does not have a link to the file on Google Drive' do
+    end
+
+    it 'does not have a link to the parent folder' do
+    end
+  end
+end

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -34,11 +34,92 @@ RSpec.describe 'file_infos/index', type: :view do
     expect(rendered).to have_link 'Open Parent Folder', href: link
   end
 
+  it 'renders No previous versions of this file' do
+    render
+    expect(rendered).to have_text 'No previous versions of this file exist.'
+  end
+
   xcontext 'when file is and has been deleted' do
     it 'does not have a link to the file on Google Drive' do
     end
 
     it 'does not have a link to the parent folder' do
+    end
+  end
+
+  context 'when file has past versions' do
+    let(:file_versions) { [diff3, diff2, diff1] }
+    let(:diff1) { VersionControl::FileDiff.new(revision_diff1, file, file) }
+    let(:diff2) { VersionControl::FileDiff.new(revision_diff2, file, file) }
+    let(:diff3) { VersionControl::FileDiff.new(revision_diff3, file, file) }
+    let(:revision_diff1)  { instance_double VersionControl::RevisionDiff }
+    let(:revision_diff2)  { instance_double VersionControl::RevisionDiff }
+    let(:revision_diff3)  { instance_double VersionControl::RevisionDiff }
+    let(:revisions)       { [revision1, revision2, revision3] }
+    let(:revision1)       { create :revision, repository: repository }
+    let(:revision2)       { create :revision, repository: repository }
+    let(:revision3)       { create :revision, repository: repository }
+    let(:repository)      { build :repository }
+    let(:file)            { build :file, name: 'File' }
+    let(:ancestors)       { [] }
+
+    before do
+      allow(revision_diff1).to receive(:base).and_return revision1
+      allow(revision_diff2).to receive(:base).and_return revision2
+      allow(revision_diff3).to receive(:base).and_return revision3
+
+      allow(diff1).to receive(:changes).and_return([:added])
+      allow(diff2).to receive(:changes).and_return(%i[moved modified])
+      allow(diff3).to receive(:changes).and_return([:deleted])
+
+      allow(diff1).to receive(:ancestors_of_file).and_return ancestors
+      allow(diff2).to receive(:ancestors_of_file).and_return ancestors
+      allow(diff3).to receive(:ancestors_of_file).and_return ancestors
+    end
+
+    it 'renders the title of each revision' do
+      render
+      revisions.each do |revision|
+        expect(rendered).to have_text revision.title
+      end
+    end
+
+    it 'renders the summary of each revision' do
+      render
+      revisions.each do |revision|
+        expect(rendered).to have_text revision.summary
+      end
+    end
+
+    it 'renders the timestamp with link for each revision' do
+      render
+      revisions.each do |revision|
+        expect(rendered).to have_link(
+          time_ago_in_words(revision.created_at),
+          href: profile_project_revisions_path(project.owner, project,
+                                               anchor: revision.id)
+        )
+      end
+    end
+
+    it 'renders the file change of each revision' do
+      render
+      expect(rendered).to have_css(
+        ".revision[id='#{revision1.id}'] .file.added",
+        text: 'File added to Home'
+      )
+      expect(rendered).to have_css(
+        ".revision[id='#{revision2.id}'] .file.modified",
+        text: 'File modified'
+      )
+      expect(rendered).to have_css(
+        ".revision[id='#{revision2.id}'] .file.moved",
+        text: 'File moved to Home'
+      )
+      expect(rendered).to have_css(
+        ".revision[id='#{revision3.id}'] .file.deleted",
+        text: 'File deleted from Home'
+      )
     end
   end
 end

--- a/spec/views/folders/show_spec.rb
+++ b/spec/views/folders/show_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe 'folders/show', type: :view do
     end
   end
 
+  it 'renders a link to infos for each file' do
+    render
+    files_and_folders.each do |file|
+      link = profile_project_file_infos_path(project.owner, project, file.id)
+      expect(rendered).to have_link(text: '', href: link)
+    end
+  end
+
   it 'does not have a button to commit changes' do
     render
     expect(rendered).not_to have_link(

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -86,6 +86,14 @@ RSpec.describe 'revisions/index', type: :view do
 
     before { assign(:revisions, [revision3, revision2, revision1]) }
 
+    it 'renders a link to infos for each file' do
+      render
+      [file1, folder, file2].each do |file|
+        link = profile_project_file_infos_path(project.owner, project, file.id)
+        expect(rendered).to have_link(text: 'More', href: link)
+      end
+    end
+
     context 'under revision 1' do
       it 'it lists file1 as added' do
         render

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -175,5 +175,11 @@ RSpec.describe 'revisions/new', type: :view do
         text: "#{modified_and_moved_file_diff.name} moved to Home > ancestor"
       )
     end
+
+    it 'marks all links as external links' do
+      render
+      expect(rendered).to have_css("a[target='_blank']")
+      expect(rendered).not_to have_css("a:not([target='_blank'])")
+    end
   end
 end


### PR DESCRIPTION
Users can check out an individual file's info page showing the file's current
status (new, uncommitted changes) and a revision history for just that one file.