### PR TITLE
Track production errors with Rollbar

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -36,6 +36,8 @@ require 'capistrano/rails/console'
 # Default puma tasks
 install_plugin Capistrano::Puma
 require 'capistrano/figaro_yml'
+# Communicate deploy information to Capistrano
+require 'rollbar/capistrano3'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,8 @@ gem 'delayed_job_active_record', '~> 4.1'
 gem 'daemons', '~> 1.2'
 # Filelock for extended file locking (simple timeout and wait)
 gem 'filelock'
+# Error-tracking with Rollbar
+gem 'rollbar', '~> 2.15'
 
 group :development, :test do
   # We will use pry rails as our console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,8 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.1)
+    rollbar (2.15.5)
+      multi_json
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -430,6 +432,7 @@ DEPENDENCIES
   puma (= 3.8.1)
   rails (~> 5.1.2)
   rails_real_favicon
+  rollbar (~> 2.15)
   rspec-rails (~> 3.5)
   rugged (~> 0.26)!
   sass-rails (~> 5.0)

--- a/app/jobs/error_report_job.rb
+++ b/app/jobs/error_report_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# Report the error to Rollbar
+class ErrorReportJob < ApplicationJob
+  queue_as :error_report
+  queue_with_priority 1
+
+  def self.call(payload)
+    ErrorReportJob.perform_later(payload)
+  end
+
+  def perform(payload)
+    Rollbar.process_from_async_handler(payload)
+  end
+end

--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -14,6 +14,9 @@ class Account < ApplicationRecord
   # Do not allow email change
   attr_readonly :email
 
+  # Delegations
+  delegate :handle, to: :user, prefix: true
+
   # Validations
   validates :user, presence: true, on: :create
   devise :validatable

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -13,6 +13,8 @@
 GOOGLE_DRIVE_CLIENT_ID: <client id from credentials.json>
 GOOGLE_DRIVE_CLIENT_SECRET: <client secret from credentials.json>
 GOOGLE_DRIVE_CREDENTIALS_PATH: '/home/user/credentials/google.yaml'
+GOOGLE_DRIVE_TRACKING_ACCOUNT: <account used for tracking changes to files>
+ROLLBAR_ACCESS_TOKEN: <access token from rollbar: post_server_item>
 
 production:
   DEPLOY_USER: <username of user for deployment>
@@ -20,6 +22,7 @@ production:
   UPSHIFT_DATABASE_NAME: <your postgres database>
   UPSHIFT_DATABASE_USERNAME: <your postgres user's username>
   UPSHIFT_DATABASE_PASSWORD: <your postgres user's password>
+  GOOGLE_DRIVE_CREDENTIALS_PATH: '/var/apps/app-name/shared/credentials/google-drive.yaml'
 
 test:
   MOCK_GOOGLE_DRIVE_REQUESTS: 'false' # set to 'true' to mock requests

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,6 +37,11 @@ set :puma_preload_app, true
 set :puma_worker_timeout, nil
 set :puma_init_active_record, true
 
+# Communicate deploy information to Rollbar
+set :rollbar_token, ENV['ROLLBAR_ACCESS_TOKEN']
+set :rollbar_env, (proc { fetch :stage })
+set :rollbar_role, (proc { :app })
+
 ## Defaults:
 # set :scm,           :git
 # set :branch,        :master

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+Rollbar.configure do |config|
+  # Without configuration, Rollbar is enabled in all environments.
+  # To disable in specific environments, set config.enabled=false.
+
+  config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+
+  # Disable Rollbar in development and test:
+  config.enabled = false if Rails.env.development?
+  config.enabled = false if Rails.env.test?
+
+  # Can overwrite development and test settings by forcing rollbar errors
+  config.enabled = true if ENV['REPORT_ERRORS'] == 'true'
+
+  # By default, Rollbar will try to call the `current_user` controller method
+  # to fetch the logged-in user object, and then call that object's `id`,
+  # `username`, and `email` methods to fetch those properties. To customize:
+  # config.person_method = "my_current_user"
+  # config.person_id_method = "my_id"
+  # config.person_username_method = "my_username"
+  # config.person_email_method = "my_email"
+
+  # If you want to attach custom data to all exception and message reports,
+  # provide a lambda like the following. It should return a hash.
+  # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+  # Add exception class names to the exception_level_filters hash to
+  # change the level that exception is reported at. Note that if an exception
+  # has already been reported and logged the level will need to be changed
+  # via the rollbar interface.
+  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+  # 'ignore' will cause the exception to not be reported at all.
+  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+  #
+  # You can also specify a callable, which will be called with the exception
+  # instance.
+  # config.exception_level_filters
+  #       .merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+  # is not installed)
+  # config.use_async = true
+  # Supply your own async handler:
+  # config.async_handler = Proc.new { |payload|
+  #  Thread.new { Rollbar.process_from_async_handler(payload) }
+  # }
+
+  # Enable asynchronous reporting (using sucker_punch)
+  # config.use_sucker_punch
+
+  # Enable delayed reporting (using Sidekiq)
+  # config.use_sidekiq
+  # You can supply custom Sidekiq options:
+  # config.use_sidekiq 'queue' => 'default'
+
+  # If your application runs behind a proxy server, you can set proxy parameters
+  # here.
+  # If https_proxy is set in your environment, that will be used. Settings here
+  # have precedence.
+  # The :host key is mandatory and must include the URL scheme (e.g. 'http://'),
+  # all other fields
+  # are optional.
+  #
+  # config.proxy = {
+  #   host: 'http://some.proxy.server',
+  #   port: 80,
+  #   user: 'username_if_auth_required',
+  #   password: 'password_if_auth_required'
+  # }
+
+  # If you run your staging application instance in production environment then
+  # you'll want to override the environment reported by `Rails.env` with an
+  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+  # setup for Heroku. See:
+  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -15,11 +15,12 @@ Rollbar.configure do |config|
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,
-  # `username`, and `email` methods to fetch those properties. To customize:
-  # config.person_method = "my_current_user"
-  # config.person_id_method = "my_id"
-  # config.person_username_method = "my_username"
-  # config.person_email_method = "my_email"
+  # `username`, and `email` methods to fetch those properties.
+  # Customize to use 'current_account' with ID, user_handle, and email
+  config.person_method = 'current_account'
+  config.person_id_method = 'id'
+  config.person_username_method = 'user_handle'
+  config.person_email_method = 'email'
 
   # If you want to attach custom data to all exception and message reports,
   # provide a lambda like the following. It should return a hash.

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -47,13 +47,10 @@ Rollbar.configure do |config|
   #  Thread.new { Rollbar.process_from_async_handler(payload) }
   # }
 
-  # Enable asynchronous reporting (using sucker_punch)
-  # config.use_sucker_punch
-
-  # Enable delayed reporting (using Sidekiq)
-  # config.use_sidekiq
-  # You can supply custom Sidekiq options:
-  # config.use_sidekiq 'queue' => 'default'
+  # Use async reporting with our own ApplicationJob error handler
+  config.use_async = true
+  config.async_handler = ErrorReportJob
+  config.failover_handlers = [Rollbar::Delay::Thread]
 
   # If your application runs behind a proxy server, you can set proxy parameters
   # here.

--- a/spec/jobs/error_report_job_spec.rb
+++ b/spec/jobs/error_report_job_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe ErrorReportJob, type: :job do
+  subject(:job) { ErrorReportJob.perform_later(payload) }
+  let(:payload) { { pay: 'load' } }
+
+  describe 'priority', delayed_job: true do
+    it { expect(subject.priority).to eq 1 }
+  end
+
+  describe 'queue', delayed_job: true do
+    it { expect(subject.queue_name).to eq 'error_report' }
+  end
+
+  describe '.call(payload)' do
+    it 'creates an ErrorReportJob' do
+      expect(ErrorReportJob).to receive(:perform_later).with kind_of(Hash)
+      ErrorReportJob.call(payload)
+    end
+  end
+
+  describe '#perform' do
+    it 'sends the error to Rollbar' do
+      expect(Rollbar).to receive(:process_from_async_handler).with(payload)
+      subject
+    end
+  end
+end

--- a/spec/lib/error_reporting_spec.rb
+++ b/spec/lib/error_reporting_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# class TestJob < ApplicationJob
+#
+# end
+
+RSpec.describe 'error reporting' do
+  # turn on error reporting
+  around(:all) do |example|
+    initial_rollbar_setting = Rollbar.configuration.enabled
+    Rollbar.configuration.enabled = true
+    example.run
+    Rollbar.configuration.enabled = initial_rollbar_setting
+  end
+
+  describe 'when an error occurs in the application' do
+    it 'creates an ErrorReportJob' do
+      expect(ErrorReportJob).to receive(:perform_later)
+      Rollbar.error 'trigger an error'
+    end
+  end
+
+  describe 'when an error occurs in a background job' do
+    # turn on delaying jobs for spec
+    around(:all) do |example|
+      initial_delayed_job_setting = Delayed::Worker.delay_jobs
+      Delayed::Worker.delay_jobs = true
+      example.run
+      Delayed::Worker.delay_jobs = initial_delayed_job_setting
+    end
+
+    it 'creates an ErrorReportJob' do
+      class JobDouble < ApplicationJob
+        def perform(*_)
+          raise 'error during job'
+        end
+      end
+
+      JobDouble.perform_later({})
+
+      expect(Rollbar).to receive(:process_from_async_handler)
+
+      Delayed::Worker.new.work_off
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe Account, type: :model do
     it { is_expected.to have_readonly_attribute(:email) }
   end
 
+  describe 'delegations' do
+    it { is_expected.to delegate_method(:handle).to(:user).with_prefix(true) }
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:user).on(:create) }
     it { is_expected.to validate_confirmation_of(:password) }


### PR DESCRIPTION
Add gem 'rollbar' to report production-level errors to Rollbar. Errors from
both the web application and from background jobs are reported.