### PR TITLE
Fix: Textarea display for Grammarly users

### DIFF
--- a/app/assets/stylesheets/shared/forms.scss
+++ b/app/assets/stylesheets/shared/forms.scss
@@ -4,7 +4,10 @@
 .input-field {
   input,
   textarea {
-    + label {
+    // Use ~ selector to correctly display input fields with labels for
+    // Grammarly users (Grammarly inserts a div each before and after every
+    // textarea)
+    ~ label {
       // scss-lint:disable ImportantRule
       // we must override any other transform rules to prevent the label from
       // overlapping the input element or textarea


### PR DESCRIPTION
Grammarly adds a div each before and after every textarea. This caused
the textarea label to not correctly position itself above the textarea
and resulted in an overlap between label and input area.