### PR TITLE
Devise: Remember logged-in accounts for one week

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -7,7 +7,7 @@ class Account < ApplicationRecord
   has_one :user, class_name: 'Profiles::User', dependent: :destroy
 
   # Devise
-  devise :database_authenticatable, :registerable
+  devise :database_authenticatable, :registerable, :rememberable
 
   # Attributes
   accepts_nested_attributes_for :user

--- a/app/views/devise/sessions/new.slim
+++ b/app/views/devise/sessions/new.slim
@@ -28,9 +28,11 @@
           = f.label :password
 
       - if devise_mapping.rememberable?
-        .field
-          = f.check_box :remember_me
-          = f.label :remember_me
+        .row
+          .field.col.s12
+            = f.check_box :remember_me
+            = f.label :remember_me
+        .spacing.v16px
 
       .row
         .col.s12

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -153,17 +153,17 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 1.week
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
 
   # If true, extends the user's remember period when remembered via cookie.
-  # config.extend_remember_period = false
+  config.extend_remember_period = true
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  # config.rememberable_options = {}
+  config.rememberable_options = { secure: true }
 
   # ==> Configuration for :validatable
   # Range for password length.

--- a/db/migrate/20180120045232_add_remember_created_at_to_accounts.rb
+++ b/db/migrate/20180120045232_add_remember_created_at_to_accounts.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Add remember_created_at column to accounts to enable support for the Devise
+# rememberable module
+class AddRememberCreatedAtToAccounts < ActiveRecord::Migration[5.1]
+  def change
+    add_column :accounts, :remember_created_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180111043112) do
+ActiveRecord::Schema.define(version: 20180120045232) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20180111043112) do
     t.string "encrypted_password", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "remember_created_at"
     t.index ["email"], name: "index_accounts_on_email", unique: true
   end
 

--- a/spec/features/session_spec.rb
+++ b/spec/features/session_spec.rb
@@ -56,4 +56,29 @@ feature 'Session' do
     # then I should be signed out
     expect(page).to have_text 'Signed out successfully'
   end
+
+  scenario 'User can choose to be remembered' do
+    # given I have an account
+    account = create(:account)
+    # and I am on the homepage
+    visit '/'
+
+    # when I click on 'Login'
+    within 'nav' do
+      click_on 'Login', exact: true
+    end
+    # and enter my email and password
+    fill_in 'Email', with: account.email
+    fill_in 'Password', with: account.password
+    # and choose 'Remember me'
+    check 'Remember me'
+    # and log in
+    click_on 'Log in'
+
+    # then I should be signed in
+    expect(page).to have_text 'Signed in successfully'
+    # and I should be remembered for one week
+    expect(account.reload.remember_expires_at)
+      .to be_within(1.minute).of(Time.zone.now + 1.week)
+  end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -20,6 +20,17 @@ RSpec.describe Account, type: :model do
     it { is_expected.to delegate_method(:handle).to(:user).with_prefix(true) }
   end
 
+  describe 'devise' do
+    context 'rememberable' do
+      it 'remembers the account for one week' do
+        subject.save
+        subject.remember_me!
+        expect(subject.remember_expires_at)
+          .to be_within(1.minute).of(Time.zone.now + 1.week)
+      end
+    end
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:user).on(:create) }
     it { is_expected.to validate_confirmation_of(:password) }


### PR DESCRIPTION
When a user logs in and checks 'Remember me', the logged in account is
remembered for up to one week. If the user revisits that site during
the week, the period is extended for another week, etc...