### PR TITLE
Add 'About' to Profiles

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -36,6 +36,6 @@ class ProfilesController < ApplicationController
   end
 
   def profile_params
-    params.require(:profiles_base).permit(:name, :picture)
+    params.require(:profiles_base).permit(:name, :picture, :about)
   end
 end

--- a/app/views/profiles/edit.slim
+++ b/app/views/profiles/edit.slim
@@ -34,6 +34,14 @@
       .col.s12.input-field
         = f.file_field :picture, accept: "image/jpeg, image/gif, image/png"
         = f.label :picture
+
+    .row
+      .col.s12.input-field
+        = f.text_area :about,
+                      rows: 3,
+                      placeholder: 'Tell the world about yourself',
+                      class: 'materialize-textarea noscript'
+        = f.label :about
         .spacing.v32px
 
     .row

--- a/app/views/profiles/show.slim
+++ b/app/views/profiles/show.slim
@@ -19,11 +19,12 @@
     = image_tag @profile.picture(:large),
                 class: 'responsive-img rounded z-depth-1'
 
-/ .container
-/   .row
-/     .col.s12
-/       div.flow-text
-/         = simple_format '250 char. bio can go here'
+- if @profile.about.present?
+  .container
+    .row
+      .col.s12
+        .flow-text
+          = simple_format html_escape(@profile.about.to_s)
 
 - if @projects.present?
   .container

--- a/app/views/profiles/show.slim
+++ b/app/views/profiles/show.slim
@@ -21,7 +21,7 @@
 
 - if @profile.about.present?
   .container
-    .row
+    .row.no-margin-bottom
       .col.s12
         .flow-text
           = simple_format html_escape(@profile.about.to_s)

--- a/db/migrate/20180128202117_add_about_to_profiles.rb
+++ b/db/migrate/20180128202117_add_about_to_profiles.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add about text (description) to profiles
+class AddAboutToProfiles < ActiveRecord::Migration[5.1]
+  def change
+    add_column :profiles, :about, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180121041308) do
+ActiveRecord::Schema.define(version: 20180128202117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 20180121041308) do
     t.string "picture_content_type"
     t.integer "picture_file_size"
     t.datetime "picture_updated_at"
+    t.text "about"
     t.index ["account_id"], name: "index_profiles_on_account_id", unique: true
     t.index ["handle"], name: "index_profiles_on_handle", unique: true
   end

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ProfilesController, type: :controller do
   end
 
   describe 'PATCH #update' do
-    let(:add_params)  { { profiles_base: { name: 'new name' } } }
+    let(:add_params)  { { profiles_base: { name: 'name', about: 'about' } } }
     let(:params)      { default_params.merge(add_params) }
     let(:run_request) { patch :update, params: params }
     before            { sign_in profile.account }

--- a/spec/factories/profiles/base.rb
+++ b/spec/factories/profiles/base.rb
@@ -2,8 +2,9 @@
 
 FactoryGirl.define do
   factory :profiles_base do
-    name { Faker::Name.name }
+    name    { Faker::Name.name }
+    about   { Faker::Lorem.paragraph }
     account { build(:account, user: Profiles::User.new(name: name)) }
-    handle { Faker::Internet.user_name(name.first(26).strip, %w[_]) }
+    handle  { Faker::Internet.user_name(name.first(26).strip, %w[_]) }
   end
 end

--- a/spec/features/user_spec.rb
+++ b/spec/features/user_spec.rb
@@ -32,8 +32,9 @@ feature 'User' do
 
     # and click on edit
     find('a#edit_profile').click
-    # and fill in a new name and picture
+    # and fill in a new name, about, and picture
     fill_in 'profiles_base_name', with: 'My New Name'
+    fill_in 'About', with: 'Info about me'
     attach_file(
       'profiles_base[picture]',
       Rails.root.join('spec', 'support', 'fixtures', 'profiles', 'picture.jpg')
@@ -44,6 +45,7 @@ feature 'User' do
 
     # then I should see my new name
     expect(page).to have_css 'h1', text: 'My New Name'
+    expect(page).to have_text 'Info about me'
     # and the picture should be saved
     expect(user.reload.picture).to be_exist
   end

--- a/spec/views/profiles/edit_spec.rb
+++ b/spec/views/profiles/edit_spec.rb
@@ -34,6 +34,11 @@ RSpec.describe 'profiles/edit', type: :view do
     expect(rendered).to have_css 'input#profiles_base_name'
   end
 
+  it 'has a textarea for about' do
+    render
+    expect(rendered).to have_css 'textarea#profiles_base_about'
+  end
+
   it 'has an input file field for picture' do
     render
     expect(rendered).to have_css 'input[type=file]#profiles_base_picture'

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -14,6 +14,11 @@ RSpec.describe 'profiles/show', type: :view do
     expect(rendered).to have_text profile.name
   end
 
+  it 'renders the about text of the profile' do
+    render
+    expect(rendered).to have_text profile.about
+  end
+
   it 'lists projects' do
     render
     projects.each do |project|


### PR DESCRIPTION
Profiles have an about field that is displayed on their profile page and can be used by the profile owner to provide additional information about the profile.