### PR TITLE
Add 'Description' to Projects

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -97,7 +97,7 @@ class ProjectsController < ApplicationController
       when :import
         %w[link_to_google_drive_folder]
       else
-        %w[title slug]
+        %w[title slug description]
       end
 
     params.require(:project).permit(*attributes)

--- a/app/views/profiles/show.slim
+++ b/app/views/profiles/show.slim
@@ -24,7 +24,7 @@
     .row.no-margin-bottom
       .col.s12
         .flow-text
-          = simple_format html_escape(@profile.about.to_s)
+          = simple_format html_escape(@profile.about)
 
 - if @projects.present?
   .container

--- a/app/views/projects/_form.slim
+++ b/app/views/projects/_form.slim
@@ -35,6 +35,14 @@
           = f.label :slug, 'Project URL (letters, numbers, and dashes)'
 
     .row
+      .col.s12.input-field
+        = f.text_area :description,
+                      rows: 3,
+                      placeholder: 'Describe this project',
+                      class: 'materialize-textarea noscript'
+        = f.label :description
+
+    .row
       .col.s12
         button action='submit' class="btn-large primary-color primary-color-text"
           = button

--- a/app/views/projects/_project.slim
+++ b/app/views/projects/_project.slim
@@ -2,3 +2,5 @@
   = link_to url_for([project.owner, project]), class: 'card hoverable'
     .card-image style="background-image: url(#{image_path('projects/banner.jpg')});"
     .card-title.truncate.primary-color.primary-color-text = project.title
+    - if project.description.present?
+      .card-content.black-text = truncate(project.description, length: 200)

--- a/app/views/projects/show.slim
+++ b/app/views/projects/show.slim
@@ -13,9 +13,16 @@
         svg viewBox="0 0 24 24"
           path fill="currentColor" d="M20.71,7.04C21.1,6.65 21.1,6 20.71,5.63L18.37,3.29C18,2.9 17.35,2.9 16.96,3.29L15.12,5.12L18.87,8.87M3,17.25V21H6.75L17.81,9.93L14.06,6.18L3,17.25Z"
 
-.container
-  h3 Overview
-  i Project description goes here (not yet implemented)
+.spacing.v32px
+
+- if @project.description.present?
+  .container
+    .row.no-margin-bottom
+      .col.s12
+        .flow-text
+          = simple_format html_escape(@project.description)
+
+
 
 .container
   / TODO: Rename to Collaborators (or another name) once we implement the teams

--- a/db/migrate/20180128205442_add_description_to_projects.rb
+++ b/db/migrate/20180128205442_add_description_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add description to projects
+class AddDescriptionToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180128202117) do
+ActiveRecord::Schema.define(version: 20180128205442) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20180128202117) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.citext "slug", null: false
+    t.text "description"
     t.index ["owner_type", "owner_id", "slug"], name: "index_projects_on_owner_type_and_owner_id_and_slug", unique: true
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner_type_and_owner_id"
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -3,7 +3,8 @@
 FactoryGirl.define do
   factory :project do
     title { Faker::HitchhikersGuideToTheGalaxy.starship.first(50).strip }
+    description     { Faker::Lorem.paragraph }
     sequence(:slug) { |n| "project-slug-#{n}" }
-    owner { build(:user) }
+    owner           { build(:user) }
   end
 end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -88,15 +88,18 @@ feature 'Project' do
     # and fill in a new title
     fill_in 'project_title',  with: 'My New Project Title'
     fill_in 'Project URL',    with: 'new-slug'
+    fill_in 'Description',    with: 'My Description'
     # and save
     click_on 'Save'
 
     # then I should be back on project_path
     expect(page)
       .to have_current_path "/#{project.owner.to_param}/new-slug"
-    # and see the new project's title
+    # and see the project's new title
     expect(page).to have_text 'My New Project Title'
-    # and see the first commit
+    # and see the project's new description
+    expect(page).to have_text 'My Description'
+    # and see a success message
     expect(page).to have_text 'Project successfully updated.'
   end
 

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -19,10 +19,11 @@ RSpec.describe 'profiles/show', type: :view do
     expect(rendered).to have_text profile.about
   end
 
-  it 'lists projects' do
+  it 'lists projects with title & description' do
     render
     projects.each do |project|
       expect(rendered).to have_text project.title
+      expect(rendered).to have_text truncate(project.description, length: 200)
     end
   end
 

--- a/spec/views/projects/edit_spec.rb
+++ b/spec/views/projects/edit_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe 'projects/edit', type: :view do
     expect(rendered).to have_css 'input#project_slug'
   end
 
+  it 'has a textarea for description' do
+    render
+    expect(rendered).to have_css 'textarea#project_description'
+  end
+
   it 'has a button to save the project' do
     render
     expect(rendered).to have_css "button[action='submit']", text: 'Save'

--- a/spec/views/projects/show_spec.rb
+++ b/spec/views/projects/show_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe 'projects/show', type: :view do
     expect(rendered).to have_text project.title
   end
 
+  it 'renders the description of the project' do
+    render
+    expect(rendered).to have_text project.description
+  end
+
   it 'renders a link to the project home page' do
     render
     expect(rendered).to have_link(


### PR DESCRIPTION
Projects have a description field that is displayed on the project#show page and can be used by the project owner to provide additional information about the project.