### PR TITLE
Add Tags to Projects

### DIFF
--- a/app/assets/stylesheets/shared/all.scss
+++ b/app/assets/stylesheets/shared/all.scss
@@ -10,6 +10,7 @@
 @import 'errors';
 @import 'footer';
 @import 'forms';
+@import 'general';
 @import 'image';
 @import 'navbar';
 @import 'page-heading';

--- a/app/assets/stylesheets/shared/cards.scss
+++ b/app/assets/stylesheets/shared/cards.scss
@@ -17,4 +17,9 @@
     @include seam('top');
     padding: 12px 24px;
   }
+
+  // Reduce top & bottom spacing on cards
+  .card-content {
+    padding: 16px 24px;
+  }
 }

--- a/app/assets/stylesheets/shared/general.scss
+++ b/app/assets/stylesheets/shared/general.scss
@@ -1,0 +1,6 @@
+// Styling for elements that do not fit anywhere else
+
+// Display no text overflow indicator when overflowing content
+.truncate.hide-text-overflow {
+  text-overflow: '';
+}

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -97,7 +97,7 @@ class ProjectsController < ApplicationController
       when :import
         %w[link_to_google_drive_folder]
       else
-        %w[title slug description]
+        %w[title slug tag_list description]
       end
 
     params.require(:project).permit(*attributes)

--- a/app/helpers/tag_helper.rb
+++ b/app/helpers/tag_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Define helpers needed for tags
+module TagHelper
+  # Convert a tag to tag case
+  # In tag case, the first character of every word is upcased. All remaining
+  # characters remain untouched
+  def tag_case(tag)
+    tag.gsub(/\w+/, &:upcase_first)
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -96,6 +96,16 @@ class Project < ApplicationRecord
     @google_drive_folder_id = GoogleDrive.link_to_id(link)
   end
 
+  # List of tags, separated by comma
+  def tag_list
+    tags.join(', ')
+  end
+
+  # Set tags by list of tags (must be comma-separated
+  def tag_list=(tag_list)
+    self.tags = tag_list.split(',').map(&:strip)
+  end
+
   # Trim whitespaces around title
   def title=(title)
     super(title.try(:strip))

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -101,9 +101,12 @@ class Project < ApplicationRecord
     tags.join(', ')
   end
 
-  # Set tags by list of tags (must be comma-separated
+  # Set tags by list of tags (must be comma-separated)
   def tag_list=(tag_list)
-    self.tags = tag_list.split(',').map(&:strip)
+    self.tags =
+      tag_list.split(',')     # Split tag list by comma delimiter
+              .map(&:squish)  # Strips spaces and squishes consecutive spaces
+              .select(&:present?) # Ignore empty tags
   end
 
   # Trim whitespaces around title

--- a/app/views/projects/_form.slim
+++ b/app/views/projects/_form.slim
@@ -36,6 +36,11 @@
 
     .row
       .col.s12.input-field
+        = f.text_field :tag_list, placeholder: 'Education, Environment, Health, ...'
+        = f.label :tag_list, 'Tags (separate by comma)'
+
+    .row
+      .col.s12.input-field
         = f.text_area :description,
                       rows: 3,
                       placeholder: 'Describe this project',

--- a/app/views/projects/_project.slim
+++ b/app/views/projects/_project.slim
@@ -2,5 +2,12 @@
   = link_to url_for([project.owner, project]), class: 'card hoverable'
     .card-image style="background-image: url(#{image_path('projects/banner.jpg')});"
     .card-title.truncate.primary-color.primary-color-text = project.title
-    - if project.description.present?
-      .card-content.black-text = truncate(project.description, length: 200)
+    - if project.tags.any? || project.description.present?
+      .card-content
+        - if project.tags.any?
+          .truncate.hide-text-overflow
+            - project.tags.each do |tag|
+              .chip.slim.tag
+                = tag_case tag
+        - if project.description.present?
+          p.black-text = truncate(project.description, length: 200)

--- a/app/views/projects/show.slim
+++ b/app/views/projects/show.slim
@@ -20,7 +20,9 @@
     .row.no-margin-bottom
       .col.s12
         - @project.tags.each do |tag|
-          .chip.tag.primary-color.primary-color-text = tag
+          .chip.tag.primary-color.primary-color-text
+            / display tag with 1st letter of every word upcased
+            = tag.gsub(/\w+/, &:upcase_first)
 
 
 - if @project.description.present?

--- a/app/views/projects/show.slim
+++ b/app/views/projects/show.slim
@@ -21,8 +21,7 @@
       .col.s12
         - @project.tags.each do |tag|
           .chip.tag.primary-color.primary-color-text
-            / display tag with 1st letter of every word upcased
-            = tag.gsub(/\w+/, &:upcase_first)
+            = tag_case tag
 
 
 - if @project.description.present?

--- a/app/views/projects/show.slim
+++ b/app/views/projects/show.slim
@@ -15,13 +15,20 @@
 
 .spacing.v32px
 
+- if @project.tags.any?
+  .container
+    .row.no-margin-bottom
+      .col.s12
+        - @project.tags.each do |tag|
+          .chip.tag.primary-color.primary-color-text = tag
+
+
 - if @project.description.present?
   .container
     .row.no-margin-bottom
       .col.s12
         .flow-text
           = simple_format html_escape(@project.description)
-
 
 
 .container

--- a/db/migrate/20180128221502_add_tags_to_projects.rb
+++ b/db/migrate/20180128221502_add_tags_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add tags (case insensitive) to projects
+class AddTagsToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :tags, :citext, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180128205442) do
+ActiveRecord::Schema.define(version: 20180128221502) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,7 @@ ActiveRecord::Schema.define(version: 20180128205442) do
     t.datetime "updated_at", null: false
     t.citext "slug", null: false
     t.text "description"
+    t.citext "tags", default: [], array: true
     t.index ["owner_type", "owner_id", "slug"], name: "index_projects_on_owner_type_and_owner_id_and_slug", unique: true
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner_type_and_owner_id"
   end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
   factory :project do
     title { Faker::HitchhikersGuideToTheGalaxy.starship.first(50).strip }
     description     { Faker::Lorem.paragraph }
+    tags            { Faker::Lorem.words }
     sequence(:slug) { |n| "project-slug-#{n}" }
     owner           { build(:user) }
   end

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -89,7 +89,7 @@ feature 'Project' do
     fill_in 'project_title',  with: 'My New Project Title'
     fill_in 'Project URL',    with: 'new-slug'
     fill_in 'Description',    with: 'My Description'
-    fill_in 'Tags',           with: 'Environment, Education, Health'
+    fill_in 'Tags',           with: 'climate   change,education , Health, NGO'
     # and save
     click_on 'Save'
 
@@ -99,9 +99,10 @@ feature 'Project' do
     # and see the project's new title
     expect(page).to have_text 'My New Project Title'
     # and see the project's new tags
-    expect(page).to have_text 'Environment'
+    expect(page).to have_text 'Climate Change'
     expect(page).to have_text 'Education'
     expect(page).to have_text 'Health'
+    expect(page).to have_text 'NGO'
     # and see the project's new description
     expect(page).to have_text 'My Description'
     # and see a success message

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -89,6 +89,7 @@ feature 'Project' do
     fill_in 'project_title',  with: 'My New Project Title'
     fill_in 'Project URL',    with: 'new-slug'
     fill_in 'Description',    with: 'My Description'
+    fill_in 'Tags',           with: 'Environment, Education, Health'
     # and save
     click_on 'Save'
 
@@ -97,6 +98,10 @@ feature 'Project' do
       .to have_current_path "/#{project.owner.to_param}/new-slug"
     # and see the project's new title
     expect(page).to have_text 'My New Project Title'
+    # and see the project's new tags
+    expect(page).to have_text 'Environment'
+    expect(page).to have_text 'Education'
+    expect(page).to have_text 'Health'
     # and see the project's new description
     expect(page).to have_text 'My Description'
     # and see a success message

--- a/spec/helpers/tag_helper_spec.rb
+++ b/spec/helpers/tag_helper_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe TagHelper, type: :helper do
+  describe '#tag_case(tag)' do
+    subject(:method)  { helper.tag_case(tag) }
+    let(:tag)         { 'my tag' }
+
+    it 'upcases the first letter of every word' do
+      is_expected.to eq 'My Tag'
+    end
+
+    context 'when tag contains uppercase characters' do
+      let(:tag) { 'my AweSOME tag' }
+
+      it 'leaves those characters unaffected' do
+        is_expected.to eq 'My AweSOME Tag'
+      end
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -324,6 +324,35 @@ RSpec.describe Project, type: :model do
     end
   end
 
+  describe '#tag_list' do
+    subject(:method)  { project.tag_list }
+    let(:tags)        { %w[one two three four] }
+    before            { project.tags = tags }
+
+    it 'returns tags joined by comma' do
+      is_expected.to eq 'one, two, three, four'
+    end
+  end
+
+  describe '#tag_list=' do
+    subject(:method)  { project.tag_list = tag_list }
+    let(:tag_list)    { 'one,two,three,four' }
+
+    it 'splits tag list into tags' do
+      method
+      expect(project.tags).to eq %w[one two three four]
+    end
+
+    context 'when list contains whitespace around tag delimiter' do
+      let(:tag_list) { 'one   ,  two, three   ,four' }
+
+      it 'strips whitespace from beginning and end of tag' do
+        method
+        expect(project.tags).to eq %w[one two three four]
+      end
+    end
+  end
+
   describe '#title=' do
     it 'strips whitespace' do
       project.title = '   lots of whitespace     '

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -351,6 +351,24 @@ RSpec.describe Project, type: :model do
         expect(project.tags).to eq %w[one two three four]
       end
     end
+
+    context 'when list contains multiple whitespaces within tag' do
+      let(:tag_list) { 'my  awesome  tag, other    tag' }
+
+      it 'squishes whitespace to single space' do
+        method
+        expect(project.tags).to eq ['my awesome tag', 'other tag']
+      end
+    end
+
+    context 'when list contains empty tags' do
+      let(:tag_list) { 'my tag, , other tag' }
+
+      it 'ignores the empty tags' do
+        method
+        expect(project.tags).to eq ['my tag', 'other tag']
+      end
+    end
   end
 
   describe '#title=' do

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -19,10 +19,11 @@ RSpec.describe 'profiles/show', type: :view do
     expect(rendered).to have_text profile.about
   end
 
-  it 'lists projects with title & description' do
+  it 'lists projects with title & tags & description' do
     render
     projects.each do |project|
       expect(rendered).to have_text project.title
+      expect(rendered).to have_text view.tag_case(project.tags.first)
       expect(rendered).to have_text truncate(project.description, length: 200)
     end
   end

--- a/spec/views/projects/edit_spec.rb
+++ b/spec/views/projects/edit_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe 'projects/edit', type: :view do
     expect(rendered).to have_css 'input#project_slug'
   end
 
+  it 'has an input field for tag list' do
+    render
+    expect(rendered).to have_css 'input#project_tag_list'
+  end
+
   it 'has a textarea for description' do
     render
     expect(rendered).to have_css 'textarea#project_description'

--- a/spec/views/projects/show_spec.rb
+++ b/spec/views/projects/show_spec.rb
@@ -18,6 +18,13 @@ RSpec.describe 'projects/show', type: :view do
     expect(rendered).to have_text project.title
   end
 
+  it 'renders the tags of the project' do
+    render
+    project.tags.each do |tag|
+      expect(rendered).to have_css '.tag', text: tag
+    end
+  end
+
   it 'renders the description of the project' do
     render
     expect(rendered).to have_text project.description

--- a/spec/views/projects/show_spec.rb
+++ b/spec/views/projects/show_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'projects/show', type: :view do
   it 'renders the tags of the project' do
     render
     project.tags.each do |tag|
-      expect(rendered).to have_css '.tag', text: tag.upcase_first
+      expect(rendered).to have_css '.tag', text: view.tag_case(tag)
     end
   end
 

--- a/spec/views/projects/show_spec.rb
+++ b/spec/views/projects/show_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'projects/show', type: :view do
   it 'renders the tags of the project' do
     render
     project.tags.each do |tag|
-      expect(rendered).to have_css '.tag', text: tag
+      expect(rendered).to have_css '.tag', text: tag.upcase_first
     end
   end
 


### PR DESCRIPTION
Projects have tags that are displayed on the project#show page. The project
owner can be supply project tags to highlight particular keywords associated
with the project.