### PR TITLE
Automatically restart DelayedJob on deployment

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -47,6 +47,8 @@ install_plugin Capistrano::Puma
 require 'capistrano/figaro_yml'
 # Communicate deploy information to Capistrano
 require 'rollbar/capistrano3'
+# DelayedJob tasks for Capistrano
+require 'capistrano/delayed_job'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,8 @@ group :development do
   gem 'capistrano3-puma',         '~> 3.1', require: false
   # Capistrano integration for the rails console
   gem 'capistrano-rails-console', '~> 2.2', require: false
+  # Capistrano integration for DelayedJob
+  gem 'capistrano3-delayed-job', '~> 1.7'
   # Generate favicons
   gem 'rails_real_favicon'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
+    capistrano3-delayed-job (1.7.5)
+      capistrano (~> 3.0, >= 3.0.0)
+      daemons (~> 1.2.4)
     capistrano3-puma (3.1.1)
       capistrano (~> 3.7)
       capistrano-bundler
@@ -416,6 +419,7 @@ DEPENDENCIES
   capistrano-rails (~> 1.3)
   capistrano-rails-console (~> 2.2)
   capistrano-rvm (~> 0.1)
+  capistrano3-delayed-job (~> 1.7)
   capistrano3-puma (~> 3.1)
   capybara (~> 2.14)
   codecov (~> 0.1)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -51,8 +51,12 @@ set :rollbar_role, (proc { :app })
 
 ## Linked Files & Directories (Default None):
 # set :linked_files, %w{config/database.yml}
+# Must link tmp/pids to allow DelayedJob to survive deployments,
+# see: https://github.com/platanus/capistrano3-delayed-job/pull/22
 set :linked_dirs,
-    %W[public/.well-known #{Settings.file_storage}
+    %W[public/.well-known
+       tmp/pids
+       #{Settings.file_storage}
        #{Settings.attachment_storage}]
 
 namespace :puma do


### PR DESCRIPTION
Install and configure gem 'capistrano3-delayed-job' for Capistrano-DelayedJob integration.