### PR TITLE
Rubocop: Ignore MethodLength and AbcSize in migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,13 @@ Metrics/BlockLength:
   Enabled: true
   Exclude:
     - spec/**/*
+
+Metrics/MethodLength:
+  Enabled: true
+  Exclude:
+    - db/migrate/*
+
+Metrics/AbcSize:
+  Enabled: true
+  Exclude:
+    - db/migrate/*

--- a/db/migrate/20171120015812_create_file_items.rb
+++ b/db/migrate/20171120015812_create_file_items.rb
@@ -2,7 +2,6 @@
 
 # Create table for project files
 class CreateFileItems < ActiveRecord::Migration[5.1]
-  # rubocop:disable Metrics/MethodLength
   def change
     create_table :file_items do |t|
       t.references :project, foreign_key: true, null: false

--- a/db/migrate/20171122062359_drop_discussions_and_replies.rb
+++ b/db/migrate/20171122062359_drop_discussions_and_replies.rb
@@ -11,7 +11,6 @@ class DropDiscussionsAndReplies < ActiveRecord::Migration[5.1]
     remove_column :projects, :questions_count
   end
 
-  # rubocop:disable Metrics/MethodLength, AbcSize
   def down
     create_table :discussions do |t|
       t.string :title, null: false

--- a/db/migrate/20171122221645_create_delayed_jobs.rb
+++ b/db/migrate/20171122221645_create_delayed_jobs.rb
@@ -2,7 +2,6 @@
 
 # Create table for storing Delayed Job background jobs
 class CreateDelayedJobs < ActiveRecord::Migration[5.1]
-  # rubocop:disable Metrics/MethodLength
   def change
     create_table :delayed_jobs, force: true do |t|
       # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20180108071756_drop_table_file_items.rb
+++ b/db/migrate/20180108071756_drop_table_file_items.rb
@@ -6,7 +6,6 @@ class DropTableFileItems < ActiveRecord::Migration[5.1]
     drop_table 'file_items'
   end
 
-  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def down
     create_table 'file_items' do |t|
       t.bigint 'project_id', null: false
@@ -29,5 +28,4 @@ class DropTableFileItems < ActiveRecord::Migration[5.1]
     add_foreign_key 'file_items', 'file_items', column: 'parent_id'
     add_foreign_key 'file_items', 'projects'
   end
-  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 end


### PR DESCRIPTION
Migrations can be quite long, depending on the number of columns of the
database table. There is no point in limiting MethodLength for
migrations.