### PR TITLE
Implement DB-backed Revisions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,8 @@ group :development, :test do
   gem 'factory_girl_rails', '~> 4.8'
   # Quickly generate fake names, urls, etc
   gem 'faker', '~> 1.8'
+  # ActiveRecord-Import for bulk creation of records
+  gem 'activerecord-import', '~> 0.22'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
       activemodel (= 5.1.2)
       activesupport (= 5.1.2)
       arel (~> 8.0)
+    activerecord-import (0.22.0)
+      activerecord (>= 3.2)
     activesupport (5.1.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -419,6 +421,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-import (~> 0.22)
   autoprefixer-rails (~> 7.1)
   bullet (~> 5.6)
   cancancan (~> 2.0)

--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -62,7 +62,7 @@ class FileInfosController < ApplicationController
     # TODO: One day this should be @file.versions or Project.find_file_by_id(id)
     # =>    which then returns the last version of the file
     @file_versions =
-      @project.revisions.all_as_diffs.map do |revision_diff|
+      @project.git_revisions.all_as_diffs.map do |revision_diff|
         revision_diff.changed_files_as_diffs.find { |diff| diff.id == @file_id }
       end
 

--- a/app/models/committed_file.rb
+++ b/app/models/committed_file.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Handles associations between revisions, file resources, and file resource
+# snapshots (committed files)
+class CommittedFile < ApplicationRecord
+  belongs_to :revision, autosave: false
+  belongs_to :file_resource, autosave: false
+  belongs_to :file_resource_snapshot, class_name: 'FileResource::Snapshot',
+                                      autosave: false
+
+  validates :file_resource_id,
+            uniqueness: {
+              scope: %i[revision_id],
+              message: 'already exists in this revision'
+            }
+  validate :file_resource_snapshot_belongs_to_file_resource
+
+  # Mark record as read only when revision is published
+  def readonly?
+    revision_published?
+  end
+
+  # Has the revision been published?
+  def revision_published?
+    revision&.published?
+  end
+
+  private
+
+  def file_resource_snapshot_belongs_to_file_resource
+    return if file_resource_snapshot.file_resource_id == file_resource_id
+    errors.add(:file_resource_snapshot, 'does not belong to file resource')
+  end
+end

--- a/app/models/committed_file.rb
+++ b/app/models/committed_file.rb
@@ -15,6 +15,23 @@ class CommittedFile < ApplicationRecord
             }
   validate :file_resource_snapshot_belongs_to_file_resource
 
+  # Execute INSERT query based on the SELECT query
+  # Order of columns must match order of select statements.
+  # For example:
+  # CommittedFile.insert_from_select_query(
+  #  [:revision_id, :file_resource_id, :file_resource_snapshot_id],
+  #  FileResource.select(1, :id, :current_snapshot_id)
+  # )
+  # Timestamps (created_at and updated_at) are automatically added.
+  def self.insert_from_select_query(columns, select_query)
+    columns.push(:created_at, :updated_at)
+
+    ActiveRecord::Base.connection.execute(
+      "INSERT INTO #{table_name} (#{columns.join(', ')})\n" +
+      select_query.select('NOW() AS created_at', 'NOW() AS updated_at').to_sql
+    )
+  end
+
   # Mark record as read only when revision is published
   def readonly?
     revision_published?

--- a/app/models/concerns/version_control.rb
+++ b/app/models/concerns/version_control.rb
@@ -9,7 +9,7 @@ module VersionControl
     # Delegations
     delegate :stage, to: :repository, prefix: :repository, allow_nil: true
     delegate :files, to: :repository_stage, allow_nil: true
-    delegate :revisions, to: :repository, allow_nil: true
+    delegate :revisions, to: :repository, prefix: :git, allow_nil: true
 
     # Callbacks
     # Safely create repository after creating object

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,6 +22,11 @@ class Project < ApplicationRecord
                         through: :staged_root_folder,
                         source: :file_resource
 
+  has_many :revisions, dependent: :destroy
+  has_many :published_revisions,
+           -> { where is_published: true },
+           class_name: 'Revision'
+
   # Attributes
   # Do not allow owner change
   attr_readonly :owner_id, :owner_type

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -22,7 +22,26 @@ class Project < ApplicationRecord
                         through: :staged_root_folder,
                         source: :file_resource
 
-  has_many :revisions, dependent: :destroy
+  has_many :staged_non_root_files,
+           -> { where is_root: false },
+           class_name: 'StagedFile'
+  has_many :non_root_file_resources_in_stage, class_name: 'FileResource',
+                                              through: :staged_non_root_files,
+                                              source: :file_resource do
+    # Return non root file resources in stage that have a current snapshot
+    def with_current_snapshot
+      where.not(file_resources: { current_snapshot: nil })
+    end
+  end
+
+  has_many :revisions, dependent: :destroy do
+    def create_draft_and_commit_files!(author)
+      ::Revision.create_draft_and_commit_files_for_project!(
+        proxy_association.owner,
+        author
+      )
+    end
+  end
   has_many :published_revisions,
            -> { where is_published: true },
            class_name: 'Revision'

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Revisions represent a snapshot of a project with all its files
+class Revision < ApplicationRecord
+  # Associations
+  belongs_to :project
+  belongs_to :parent, class_name: 'Revision', optional: true, autosave: false
+  belongs_to :author, class_name: 'Profiles::User'
+
+  # attributes
+  attr_readonly :project_id, :parent_id, :author_id
+
+  # Validations
+  # Require title and summary for published revisions
+  with_options if: :published? do
+    validates :title, presence: true
+    validates :summary, presence: true
+  end
+
+  validate :parent_must_belong_to_same_project, if: :parent_id
+  validate :can_only_have_one_revision_with_parent, if: :parent_id
+  validate :can_only_have_one_origin_revision_per_project, unless: :parent_id
+
+  def published?
+    is_published
+  end
+
+  private
+
+  def can_only_have_one_origin_revision_per_project
+    return unless published_origin_revision_exists_for_project?
+    errors.add(:base, 'An origin revision already exists for this project')
+  end
+
+  def can_only_have_one_revision_with_parent
+    return unless published_revision_with_parent_exists?
+    errors.add(:base,
+               'Someone has committed changes to this project since you ' \
+               'started reviewing changes. To prevent you and your team from' \
+               "overwriting each other's changes, you cannot commit the " \
+               'changes you are currently reviewing.')
+  end
+
+  def parent_must_belong_to_same_project
+    return if parent.project_id == project_id
+    errors.add(:parent, 'must belong to same project')
+  end
+
+  def published_origin_revision_exists_for_project?
+    self.class.exists?(project_id: project_id, parent: nil, is_published: true)
+  end
+
+  def published_revision_with_parent_exists?
+    self.class.exists?(parent_id: parent_id, is_published: true)
+  end
+end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -6,6 +6,7 @@ class Revision < ApplicationRecord
   belongs_to :project
   belongs_to :parent, class_name: 'Revision', optional: true, autosave: false
   belongs_to :author, class_name: 'Profiles::User'
+  has_many :committed_files, dependent: :destroy
 
   # attributes
   attr_readonly :project_id, :parent_id, :author_id

--- a/db/migrate/20180218205712_create_revisions.rb
+++ b/db/migrate/20180218205712_create_revisions.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Create table for project revisions
+class CreateRevisions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :revisions do |t|
+      t.belongs_to :project, null: false, foreign_key: true
+      t.belongs_to :parent, null: true, foreign_key: { to_table: :revisions }
+      t.belongs_to :author, null: false, foreign_key: { to_table: :profiles }
+      t.boolean :is_published, null: false, default: false
+      t.string :title
+      t.text :summary
+
+      # Can only have one published revision per parent
+      t.index :parent_id,
+              name: 'index_revisions_on_published_parent_id',
+              unique: true,
+              where: 'is_published IS TRUE'
+
+      # Can only have one root revision (revision without a parent)
+      t.index :project_id,
+              name: 'index_revisions_on_published_root_revision',
+              unique: true,
+              where: 'parent_id IS NULL AND is_published IS TRUE'
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180218233707_create_committed_files.rb
+++ b/db/migrate/20180218233707_create_committed_files.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Create table for associating revisions to file resources & snapshots
+# (committed files)
+class CreateCommittedFiles < ActiveRecord::Migration[5.1]
+  def change
+    create_table :committed_files do |t|
+      t.belongs_to :revision, null: false, index: false, foreign_key: true
+      t.belongs_to :file_resource, null: false, foreign_key: true
+      t.belongs_to :file_resource_snapshot, null: false, foreign_key: true
+
+      # Each file can exist only once per revision
+      t.index %i[revision_id file_resource_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180218205712) do
+ActiveRecord::Schema.define(version: 20180218233707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,17 @@ ActiveRecord::Schema.define(version: 20180218205712) do
     t.datetime "updated_at", null: false
     t.datetime "remember_created_at"
     t.index ["email"], name: "index_accounts_on_email", unique: true
+  end
+
+  create_table "committed_files", force: :cascade do |t|
+    t.bigint "revision_id", null: false
+    t.bigint "file_resource_id", null: false
+    t.bigint "file_resource_snapshot_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["file_resource_id"], name: "index_committed_files_on_file_resource_id"
+    t.index ["file_resource_snapshot_id"], name: "index_committed_files_on_file_resource_snapshot_id"
+    t.index ["revision_id", "file_resource_id"], name: "index_committed_files_on_revision_id_and_file_resource_id", unique: true
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
@@ -144,6 +155,9 @@ ActiveRecord::Schema.define(version: 20180218205712) do
     t.index ["project_id"], name: "index_staged_files_on_root", unique: true, where: "(is_root IS TRUE)"
   end
 
+  add_foreign_key "committed_files", "file_resource_snapshots"
+  add_foreign_key "committed_files", "file_resources"
+  add_foreign_key "committed_files", "revisions"
   add_foreign_key "file_resource_snapshots", "file_resources", column: "parent_id"
   add_foreign_key "file_resources", "file_resource_snapshots", column: "current_snapshot_id"
   add_foreign_key "file_resources", "file_resources", column: "parent_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180217223610) do
+ActiveRecord::Schema.define(version: 20180218205712) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -111,6 +111,22 @@ ActiveRecord::Schema.define(version: 20180217223610) do
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner_type_and_owner_id"
   end
 
+  create_table "revisions", force: :cascade do |t|
+    t.bigint "project_id", null: false
+    t.bigint "parent_id"
+    t.bigint "author_id", null: false
+    t.boolean "is_published", default: false, null: false
+    t.string "title"
+    t.text "summary"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["author_id"], name: "index_revisions_on_author_id"
+    t.index ["parent_id"], name: "index_revisions_on_parent_id"
+    t.index ["parent_id"], name: "index_revisions_on_published_parent_id", unique: true, where: "(is_published IS TRUE)"
+    t.index ["project_id"], name: "index_revisions_on_project_id"
+    t.index ["project_id"], name: "index_revisions_on_published_root_revision", unique: true, where: "((parent_id IS NULL) AND (is_published IS TRUE))"
+  end
+
   create_table "signups", force: :cascade do |t|
     t.text "email"
     t.datetime "created_at", null: false
@@ -132,6 +148,9 @@ ActiveRecord::Schema.define(version: 20180217223610) do
   add_foreign_key "file_resources", "file_resource_snapshots", column: "current_snapshot_id"
   add_foreign_key "file_resources", "file_resources", column: "parent_id"
   add_foreign_key "profiles", "accounts"
+  add_foreign_key "revisions", "profiles", column: "author_id"
+  add_foreign_key "revisions", "projects"
+  add_foreign_key "revisions", "revisions", column: "parent_id"
   add_foreign_key "staged_files", "file_resources"
   add_foreign_key "staged_files", "projects"
 end

--- a/lib/tasks/performance/commit_all_files_staged_in_project.rake
+++ b/lib/tasks/performance/commit_all_files_staged_in_project.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+desc 'Performance: Commit all files staged in project'
+namespace :performance do
+  task commit_all_files_staged_in_project:
+       ['commit_all_files_staged_in_project:all']
+
+  namespace :commit_all_files_staged_in_project do
+    task all: %i[cleanup prepare test]
+  end
+end

--- a/lib/tasks/performance/commit_all_files_staged_in_project/cleanup.rake
+++ b/lib/tasks/performance/commit_all_files_staged_in_project/cleanup.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+desc 'Performance: Commit all files staged in project: Cleanup'
+namespace :performance do
+  namespace :commit_all_files_staged_in_project do
+    task cleanup: :test_environment do
+      puts 'Cleanup: StagedFile'
+      StagedFile.delete_all
+      puts 'Cleanup: CommittedFile'
+      CommittedFile.delete_all
+      puts 'Cleanup: Reset current snapshot'
+      FileResource.in_batches(of: 10_000).each_with_index do |relation, n|
+        relation.update_all(current_snapshot_id: nil)
+        puts "Progress: #{(n + 1)}x10000"
+      end
+      puts 'Cleanup: Snapshot'
+      FileResource::Snapshot.delete_all
+      puts 'Cleanup: FileResource'
+      FileResource.in_batches(of: 10_000).each_with_index do |relation, n|
+        relation.delete_all
+        puts "Progress: #{(n + 1)}x10000"
+      end
+      puts 'Cleanup: Revision'
+      Revision.delete_all
+      puts 'Cleanup: Project'
+      Project.delete_all
+
+      puts 'Cleanup...Done'
+    end
+  end
+end

--- a/lib/tasks/performance/commit_all_files_staged_in_project/prepare.rake
+++ b/lib/tasks/performance/commit_all_files_staged_in_project/prepare.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'factory_girl'
+
+desc 'Performance: Commit all files staged in project: Prepare'
+namespace :performance do
+  namespace :commit_all_files_staged_in_project do
+    task prepare: :test_environment do
+      puts 'Preparing database'
+
+      snapshot_id = FactoryGirl.create(:file_resource_snapshot).id
+      batch_size = 10_000
+      columns = %i[provider_id external_id mime_type name content_version
+                   current_snapshot_id]
+
+      8.times do |n|
+        rows = []
+        batch_size.times do |batch_n|
+          rows << [0, (batch_n + batch_size * n).to_s, 'doc', 'name', '1',
+                   snapshot_id]
+        end
+        FileResource.import columns, rows, validate: false
+        puts "Progress: #{(n + 1) * batch_size} records created"
+      end
+
+      puts 'Staging all file resources'
+
+      project = FactoryGirl.create(:project)
+      rows = FileResource.all.pluck(:id).map { |v| [v].push(project.id) }
+      StagedFile.import %i[file_resource_id project_id], rows, validate: false
+
+      puts 'Preparing database...Done'
+    end
+  end
+end

--- a/lib/tasks/performance/commit_all_files_staged_in_project/test.rake
+++ b/lib/tasks/performance/commit_all_files_staged_in_project/test.rake
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+desc 'Performance: Commit all files staged in project: Test'
+namespace :performance do
+  namespace :commit_all_files_staged_in_project do
+    task test: :test_environment do
+      project = Project.last
+
+      puts "Benchmarking with #{project.staged_files.count} records"
+
+      revision = Revision.create(project: project, parent: nil,
+                                 author: project.owner)
+      time = Benchmark.realtime { revision.commit_all_files_staged_in_project }
+
+      puts "Completed in #{time} seconds"
+    end
+  end
+end

--- a/lib/tasks/performance/test_environment.rake
+++ b/lib/tasks/performance/test_environment.rake
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+desc 'Abort unless Rails is in test environment'
+task test_environment: :environment do
+  abort('Task should be run in test environment!') unless Rails.env.test?
+end

--- a/spec/factories/committed_files.rb
+++ b/spec/factories/committed_files.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :committed_file do
+    revision
+    file_resource
+    file_resource_snapshot { file_resource.current_snapshot }
+  end
+end

--- a/spec/factories/file_resources.rb
+++ b/spec/factories/file_resources.rb
@@ -11,5 +11,12 @@ FactoryGirl.define do
     trait :with_parent do
       association :parent, factory: :file_resource
     end
+
+    trait :deleted do
+      name nil
+      content_version nil
+      mime_type nil
+      is_deleted true
+    end
   end
 end

--- a/spec/factories/profiles/users.rb
+++ b/spec/factories/profiles/users.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 FactoryGirl.define do
-  factory :user,
-          class: Profiles::User,
-          parent: :profiles_base do
+  factory :user, aliases: %i[author],
+                 class: Profiles::User, parent: :profiles_base do
   end
 end

--- a/spec/factories/revisions.rb
+++ b/spec/factories/revisions.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :revision do
+    author
+    project
+    title         { Faker::HarryPotter.quote }
+    summary       { Faker::Lorem.paragraph }
+    is_published  false
+
+    trait :published do
+      is_published true
+    end
+
+    trait :with_parent do
+      parent { create(:revision, project: project) }
+    end
+
+    after(:build) do |revision|
+      next if revision.parent&.project.nil?
+      revision.project = revision.parent.project
+    end
+  end
+end

--- a/spec/factories/version_control/committed_file.rb
+++ b/spec/factories/version_control/committed_file.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     skip_create
 
     initialize_with do
-      create :revision, repository: repository
+      create :git_revision, repository: repository
       new(
         repository.revisions.last.files,
         id: id,

--- a/spec/factories/version_control/committed_file.rb
+++ b/spec/factories/version_control/committed_file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryGirl.define do
-  factory :committed_file,
+  factory :git_committed_file,
           class: VersionControl::Files::Committed,
           parent: :file do
     skip_create

--- a/spec/factories/version_control/revision.rb
+++ b/spec/factories/version_control/revision.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryGirl.define do
-  factory :revision, class: VersionControl::Revisions::Committed do
+  factory :git_revision, class: VersionControl::Revisions::Committed do
     skip_create
 
     transient do

--- a/spec/features/file_info_spec.rb
+++ b/spec/features/file_info_spec.rb
@@ -7,7 +7,7 @@ feature 'File Info' do
     # with a committed file
     root = create :file, :root, repository: project.repository
     file = create :file, name: 'File1', parent: root
-    first_revision = create :revision, repository: project.repository
+    first_revision = create :git_revision, repository: project.repository
 
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"
@@ -57,9 +57,9 @@ feature 'File Info' do
     # with a committed file that has been deleted
     root = create :file, :root, repository: project.repository
     file = create :file, name: 'File1', parent: root
-    first_revision = create :revision, repository: project.repository
+    first_revision = create :git_revision, repository: project.repository
     file.destroy
-    second_revision = create :revision, repository: project.repository
+    second_revision = create :git_revision, repository: project.repository
 
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"

--- a/spec/features/file_update_spec.rb
+++ b/spec/features/file_update_spec.rb
@@ -30,7 +30,7 @@ feature 'File Update', :vcr do
     "https://drive.google.com/drive/folders/#{google_drive_test_folder_id}"
   end
   let!(:token)  { GoogleDrive.get_changes_start_page_token.start_page_token }
-  let(:commit)  { create :revision, repository: project.repository }
+  let(:commit)  { create :git_revision, repository: project.repository }
 
   scenario 'In Google Drive, user creates file within project folder' do
     given_project_is_imported_and_changes_committed

--- a/spec/features/folder_spec.rb
+++ b/spec/features/folder_spec.rb
@@ -80,7 +80,7 @@ feature 'Folder' do
     removed_file                = create :file, parent: folder
     unchanged_file              = create :file, parent: folder
     # and files are committed
-    create :revision, repository: project.repository
+    create :git_revision, repository: project.repository
 
     # when changes are made to files
     added_file = create :file, parent: folder
@@ -120,7 +120,7 @@ feature 'Folder' do
     let!(:code)     { create :file, :folder, name: 'Code',      parent: docs }
     before do
       # and folders are committed
-      create :revision, repository: project.repository
+      create :git_revision, repository: project.repository
     end
     let(:action) do
       # when I visit the code folder

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -13,13 +13,13 @@ feature 'Revision' do
     # =>    a commit is made. If that implementation changes, this spec would
     # =>    still pass.
     first_revision =
-      create :revision, repository: project.repository, author: users[0]
+      create :git_revision, repository: project.repository, author: users[0]
     file.update(modified_time: Time.zone.now)
     second_revision =
-      create :revision, repository: project.repository, author: users[1]
+      create :git_revision, repository: project.repository, author: users[1]
     file.destroy
     third_revision =
-      create :revision, repository: project.repository, author: users[2]
+      create :git_revision, repository: project.repository, author: users[2]
 
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"
@@ -85,7 +85,7 @@ feature 'Revision' do
     moved_folder                = create :file, :folder, parent: root
     create_list :file, 5, parent: moved_folder
     # and files are committed
-    create :revision, repository: project.repository
+    create :git_revision, repository: project.repository
     # and I am signed in as its owner
     sign_in_as project.owner.account
 

--- a/spec/integrations/committed_file_spec.rb
+++ b/spec/integrations/committed_file_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe CommittedFile, type: :model do
+  subject(:file) { build(:committed_file) }
+
+  describe 'validation: file resource snapshot must belong to file resource' do
+    let(:file_resource) { file.file_resource }
+    before              { file.file_resource_snapshot = snapshot }
+
+    context 'when file resource snapshot belongs to file resource' do
+      let(:snapshot) { file_resource.current_snapshot }
+      it             { is_expected.to be_valid }
+    end
+
+    context 'when file resource snapshot does not belong to file resource' do
+      let(:snapshot) { create(:file_resource_snapshot) }
+      it             { is_expected.to be_invalid }
+    end
+  end
+end

--- a/spec/integrations/revision_spec.rb
+++ b/spec/integrations/revision_spec.rb
@@ -57,4 +57,54 @@ RSpec.describe Revision, type: :model do
       it              { is_expected.to be_valid }
     end
   end
+
+  describe '#commit_all_files_staged_in_project' do
+    subject(:committed_files)     { revision.committed_files }
+    let(:revision)                { create :revision }
+    let(:project)                 { revision.project }
+    let(:file_resources_in_stage) { create_list :file_resource, 10 }
+    let(:root_file)               { create :file_resource }
+    let(:commit_files) { revision.commit_all_files_staged_in_project }
+
+    # Create staged files in another project
+    # This is to ensure that committing affects only the files staged for the
+    # specific project we are staging for
+    before do
+      other_project = create(:project)
+      other_project.file_resources_in_stage = create_list(:file_resource, 10)
+    end
+
+    before { project.file_resources_in_stage = file_resources_in_stage }
+    before { project.create_staged_root_folder(file_resource: root_file) }
+    before { commit_files }
+
+    it { expect(subject.count).to eq 10 }
+
+    it 'has the correct file resource IDs & file resource snapshot IDs' do
+      committed =
+        subject.map { |f| [f.file_resource_id, f.file_resource_snapshot_id] }
+      staged = file_resources_in_stage.map { |f| [f.id, f.current_snapshot_id] }
+      expect(committed).to contain_exactly(*staged)
+    end
+
+    it 'does not commit the root file' do
+      is_expected.not_to be_exists(file_resource: root_file)
+    end
+
+    context 'when no files are staged' do
+      let(:file_resources_in_stage) { [] }
+
+      it { is_expected.to be_none }
+    end
+
+    context 'when a file resource with current_snapshot=nil is in stage' do
+      let(:file_resources_in_stage)       { [file_without_current_snapshot] }
+      let(:file_without_current_snapshot) { create :file_resource, :deleted }
+
+      it 'does not commit that file' do
+        is_expected
+          .not_to be_exists(file_resource: file_without_current_snapshot)
+      end
+    end
+  end
 end

--- a/spec/integrations/revision_spec.rb
+++ b/spec/integrations/revision_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe Revision, type: :model do
+  subject(:revision) { build(:revision) }
+
+  describe 'validation: parent must belong to same project' do
+    let(:parent)        { create(:revision) }
+    before              { revision.parent = parent }
+
+    context 'when parent revision belongs to different project' do
+      before  { revision.project = create(:project) }
+      it      { is_expected.to be_invalid }
+    end
+
+    context 'when parent revision belongs to same project' do
+      before  { revision.project = parent.project }
+      it      { is_expected.to be_valid }
+    end
+  end
+
+  describe 'validation: can have only one origin revision per project' do
+    subject(:new_origin) { build(:revision, project: project) }
+    let(:project)        { create(:project) }
+
+    context 'when published origin revision exists in project' do
+      let!(:existing_origin) { create :revision, :published, project: project }
+      it                     { is_expected.to be_invalid }
+    end
+
+    context 'when origin revision in project is not published' do
+      let!(:existing_origin) { create :revision, project: project }
+      it                     { is_expected.to be_valid }
+    end
+
+    context 'when origin revision exists in another project' do
+      let!(:existing_origin) { create :revision, :published }
+      it { is_expected.to be_valid }
+    end
+  end
+
+  describe 'validation: can have only one revision with parent' do
+    subject(:revision)  { build(:revision, parent: parent) }
+    let(:parent)        { create(:revision) }
+
+    context 'when revision with same parent exists' do
+      let!(:existing) { create :revision, :published, parent: parent }
+      it              { is_expected.to be_invalid }
+    end
+
+    context 'when revision with same parent is not published' do
+      let!(:existing) { create :revision, parent: parent }
+      it              { is_expected.to be_valid }
+    end
+
+    context 'when revision with same parent does not exist' do
+      let!(:existing) { create :revision, :with_parent }
+      it              { is_expected.to be_valid }
+    end
+  end
+end

--- a/spec/integrations/shared_examples/including_stageable_integration.rb
+++ b/spec/integrations/shared_examples/including_stageable_integration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'including stageable integration' do
-  subject(:staged_projects) { stageable.staging_projects }
+  subject(:staged_projects) { stageable.staging_projects.to_a }
   let(:p1) { create :project }
   let(:p2) { create :project }
   let(:p3) { create :project }
@@ -18,7 +18,7 @@ RSpec.shared_examples 'including stageable integration' do
 
   describe 'parent is set from nil' do
     before { stageable.update(parent: parent) }
-    it     { is_expected.to eq [p1, p2, p3, p4] }
+    it     { is_expected.to contain_exactly(p1, p2, p3, p4) }
   end
 
   describe 'parent is updated' do
@@ -37,7 +37,7 @@ RSpec.shared_examples 'including stageable integration' do
     describe 'parent is staged in some projects' do
       let(:staging_projects_of_new_parent) { [p3, p4, p5, p6] }
 
-      it { is_expected.to eq [p3, p4, p5, p6] }
+      it { is_expected.to contain_exactly(p3, p4, p5, p6) }
     end
 
     describe 'parent is staged in no projects' do
@@ -58,7 +58,7 @@ RSpec.shared_examples 'including stageable integration' do
 
     it 'does not delete stagings as root' do
       stageable.update(parent: parent)
-      is_expected.to eq [p1, p2, p3, p4, p5, p6]
+      is_expected.to contain_exactly(p1, p2, p3, p4, p5, p6)
     end
   end
 end

--- a/spec/integrations/version_control/revision_collection_spec.rb
+++ b/spec/integrations/version_control/revision_collection_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe VersionControl::RevisionCollection, type: :model do
 
   describe '#all' do
     subject(:method)        { revision_collection.all }
-    let!(:oldest_revision)  { create :revision, repository: repository }
-    let!(:second_revision)  { create :revision, repository: repository }
-    let!(:newest_revision)  { create :revision, repository: repository }
+    let!(:oldest_revision)  { create :git_revision, repository: repository }
+    let!(:second_revision)  { create :git_revision, repository: repository }
+    let!(:newest_revision)  { create :git_revision, repository: repository }
 
     it 'returns all three revisions' do
       expect(method.map(&:id)).to contain_exactly(
@@ -33,9 +33,9 @@ RSpec.describe VersionControl::RevisionCollection, type: :model do
 
   describe '#all_as_diffs' do
     subject(:method)        { revision_collection.all_as_diffs }
-    let!(:oldest_revision)  { create :revision, repository: repository }
-    let!(:second_revision)  { create :revision, repository: repository }
-    let!(:newest_revision)  { create :revision, repository: repository }
+    let!(:oldest_revision)  { create :git_revision, repository: repository }
+    let!(:second_revision)  { create :git_revision, repository: repository }
+    let!(:newest_revision)  { create :git_revision, repository: repository }
 
     it 'returns three revision diffs' do
       expect(method).to be_an Array

--- a/spec/integrations/version_control/revision_diff_spec.rb
+++ b/spec/integrations/version_control/revision_diff_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
     let!(:deleted_file)   { create :file, parent: root }
 
     # commit
-    before                { create :revision, repository: repository }
+    before                { create :git_revision, repository: repository }
 
     # make some changes
     let!(:added_file)     { create :file, :folder, parent: root }
@@ -55,7 +55,7 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
       # initialize differentiator
       let!(:differentiator) { repository.revisions.last }
       # commit again & initialize base
-      let(:base) { create :revision, repository: repository }
+      let(:base) { create :git_revision, repository: repository }
 
       it 'still returns four FileDiffs' do
         expect(method.map(&:class).uniq).to eq [VersionControl::FileDiff]
@@ -73,10 +73,10 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
 
     context 'when no files have changed' do
       # commit again & initialize differentiator
-      let!(:differentiator) { create :revision, repository: repository }
+      let!(:differentiator) { create :git_revision, repository: repository }
       before { repository.revisions.reload }
       # commit again & initialize base
-      let(:base) { create :revision, repository: repository }
+      let(:base) { create :git_revision, repository: repository }
 
       it { is_expected.to eq [] }
     end
@@ -90,7 +90,7 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
     context 'when folder with files is moved' do
       let!(:child)        { create :file, parent: folder }
       let!(:other_folder) { create :file, :folder, parent: root }
-      before              { create :revision, repository: repository }
+      before              { create :git_revision, repository: repository }
       # move the folder
       before              { folder.update(parent_id: other_folder.id) }
 

--- a/spec/models/committed_file_spec.rb
+++ b/spec/models/committed_file_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+RSpec.describe CommittedFile, type: :model do
+  subject(:file) { build_stubbed :committed_file }
+
+  describe 'associations' do
+    it do
+      is_expected.to belong_to(:revision).autosave(false).dependent(false)
+    end
+    it do
+      is_expected.to belong_to(:file_resource).autosave(false).dependent(false)
+    end
+    it do
+      is_expected
+        .to belong_to(:file_resource_snapshot)
+        .class_name('FileResource::Snapshot')
+        .dependent(false)
+    end
+  end
+
+  describe 'validations' do
+    subject(:file) { build :committed_file }
+
+    it do
+      is_expected
+        .to validate_uniqueness_of(:file_resource_id)
+        .scoped_to(:revision_id)
+        .with_message('already exists in this revision')
+    end
+  end
+
+  describe 'read-only instance' do
+    subject(:file)  { build :committed_file }
+    let(:create)    { file.save }
+    let(:update)    { create && file.update(updated_at: Time.zone.now) }
+    let(:destroy)   { create && file.destroy }
+
+    before { allow(file).to receive(:revision_published?).and_return published }
+
+    context 'when revision is not published' do
+      let(:published) { false }
+
+      it { expect { create }.not_to raise_error }
+      it { expect { update }.not_to raise_error }
+      it { expect { destroy }.not_to raise_error }
+    end
+
+    context 'when revision is published' do
+      let(:published) { true }
+
+      it { expect { create }.to raise_error ActiveRecord::ReadOnlyRecord }
+      it { expect { update }.to raise_error ActiveRecord::ReadOnlyRecord }
+      it { expect { destroy }.to raise_error ActiveRecord::ReadOnlyRecord }
+    end
+  end
+end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Project, type: :model do
         .source(:file_resource)
         .dependent(false)
     end
+    it { is_expected.to have_many(:revisions).dependent(:destroy) }
+    it do
+      is_expected
+        .to have_many(:published_revisions)
+        .class_name('Revision')
+        .conditions(is_published: true)
+        .dependent(false)
+    end
   end
 
   describe 'attributes' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe Project, type: :model do
         .source(:file_resource)
         .dependent(false)
     end
+    it do
+      is_expected
+        .to have_many(:staged_non_root_files)
+        .conditions(is_root: false)
+        .class_name('StagedFile')
+        .dependent(false)
+    end
+    it do
+      is_expected
+        .to have_many(:non_root_file_resources_in_stage)
+        .class_name('FileResource')
+        .through(:staged_non_root_files)
+        .source(:file_resource)
+        .dependent(false)
+    end
     it { is_expected.to have_many(:revisions).dependent(:destroy) }
     it do
       is_expected
@@ -277,6 +292,19 @@ RSpec.describe Project, type: :model do
           'projects'
         ).cleanpath.to_s
       )
+    end
+  end
+
+  describe 'revisions#create_draft_and_commit_files!' do
+    subject(:method) do
+      project.revisions.create_draft_and_commit_files!('author')
+    end
+
+    it 'calls Revision#create_draft_and_commit_files_for_project!' do
+      expect(Revision)
+        .to receive(:create_draft_and_commit_files_for_project!)
+        .with(project, 'author')
+      method
     end
   end
 

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe Revision, type: :model do
+  subject(:revision) { build_stubbed :revision }
+  describe 'associations' do
+    it { is_expected.to belong_to(:project).dependent(false) }
+    it do
+      is_expected
+        .to belong_to(:parent)
+        .class_name('Revision')
+        .autosave(false)
+        .dependent(false)
+    end
+    it do
+      is_expected
+        .to belong_to(:author).class_name('Profiles::User').dependent(false)
+    end
+  end
+
+  describe 'attributes' do
+    it { is_expected.to have_readonly_attribute(:project_id) }
+    it { is_expected.to have_readonly_attribute(:parent_id) }
+    it { is_expected.to have_readonly_attribute(:author_id) }
+  end
+
+  describe 'validations' do
+    it { is_expected.not_to validate_presence_of(:title) }
+    it { is_expected.not_to validate_presence_of(:summary) }
+
+    context 'when is_published=true' do
+      before  { revision.is_published = true }
+      it      { is_expected.to validate_presence_of(:title) }
+      it      { is_expected.to validate_presence_of(:summary) }
+    end
+  end
+end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -34,4 +34,63 @@ RSpec.describe Revision, type: :model do
       it      { is_expected.to validate_presence_of(:summary) }
     end
   end
+
+  describe '.create_draft_and_commit_files_for_project!(project, author)' do
+    subject(:create_draft) do
+      described_class
+        .create_draft_and_commit_files_for_project!(project, author)
+    end
+    let(:draft)     { instance_double Revision }
+    let(:project)   { instance_double Project }
+    let(:author)    { instance_double Profiles::User }
+    let(:revisions) { %w[rev1 rev2 rev3] }
+
+    before do
+      allow(described_class).to receive(:create!).and_return(draft)
+      allow(draft).to receive(:commit_all_files_staged_in_project)
+      allow(project).to receive(:published_revisions).and_return revisions
+    end
+
+    after { create_draft }
+
+    it { is_expected.to eq draft }
+
+    it 'calls create! with project, last revision, and author' do
+      expect(described_class).to receive(:create!).with(
+        project: project, parent: 'rev3', author: author
+      )
+    end
+
+    it { expect(draft).to receive(:commit_all_files_staged_in_project) }
+  end
+
+  describe '#commit_all_files_staged_in_project' do
+    subject(:commit_files) { revision.commit_all_files_staged_in_project }
+    let(:columns) { %i[file_resource_id file_resource_snapshot_id revision_id] }
+    let(:rows)    { [%w[f1 s1 r], %w[f2 s2 r], %w[f3 s3 r]] }
+    let(:query)   { class_double ActiveRecord::Relation }
+
+    before do
+      allow(CommittedFile).to receive(:insert_from_select_query)
+      collection_proxy = class_double FileResource
+      allow(revision.project)
+        .to receive_message_chain(
+          :non_root_file_resources_in_stage,
+          :with_current_snapshot
+        ).and_return collection_proxy
+      allow(collection_proxy)
+        .to receive(:select)
+        .with('r', :id, :current_snapshot_id)
+        .and_return query
+      allow(revision).to receive(:id).and_return 'r'
+    end
+
+    it 'calls CommittedFile.insert_from_select_query' do
+      expect(CommittedFile)
+        .to receive(:insert_from_select_query)
+        .with(%i[revision_id file_resource_id file_resource_snapshot_id],
+              query)
+      commit_files
+    end
+  end
 end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe Revision, type: :model do
       is_expected
         .to belong_to(:author).class_name('Profiles::User').dependent(false)
     end
+    it { is_expected.to have_many(:committed_files).dependent(:destroy) }
   end
 
   describe 'attributes' do

--- a/spec/models/shared_examples/having_version_control.rb
+++ b/spec/models/shared_examples/having_version_control.rb
@@ -65,9 +65,9 @@ RSpec.shared_examples 'having version control' do
       subject.send :files
     end
 
-    it 'delegates revisions to repository' do
+    it 'delegates revisions to repository with prefix :git' do
       expect_any_instance_of(VersionControl::Repository).to receive :revisions
-      subject.send :revisions
+      subject.send :git_revisions
     end
 
     context 'when repository is nil' do
@@ -81,8 +81,8 @@ RSpec.shared_examples 'having version control' do
         expect(subject.send(:files)).to eq nil
       end
 
-      it 'returns nil on calling #revisions' do
-        expect(subject.send(:revisions)).to eq nil
+      it 'returns nil on calling #git_revisions' do
+        expect(subject.send(:git_revisions)).to eq nil
       end
     end
   end

--- a/spec/models/shared_examples/version_control/for_file_diff.rb
+++ b/spec/models/shared_examples/version_control/for_file_diff.rb
@@ -149,5 +149,5 @@ RSpec.shared_context 'file diff with files' do
   let(:create_files)                  { nil }
   let(:after_file_creation_callback) { create_revision }
   # create revision for the repository as callback
-  let(:create_revision) { create :revision, repository: repository }
+  let(:create_revision) { create :git_revision, repository: repository }
 end

--- a/spec/models/version_control/file_collections/committed_spec.rb
+++ b/spec/models/version_control/file_collections/committed_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe VersionControl::FileCollections::Committed, type: :model do
     repository.revisions.last.files
   end
   let(:repository)      { build :repository }
-  let(:create_revision) { create :revision, repository: repository }
+  let(:create_revision) { create :git_revision, repository: repository }
   let(:root)            { create :file, :root, repository: repository }
 
   it_should_behave_like 'being a file collection'

--- a/spec/models/version_control/files/committed_spec.rb
+++ b/spec/models/version_control/files/committed_spec.rb
@@ -4,7 +4,7 @@ require 'models/shared_examples/version_control/being_a_file.rb'
 require 'models/shared_examples/caching_method_call.rb'
 
 RSpec.describe VersionControl::Files::Staged, type: :model do
-  subject(:file)          { build :committed_file }
+  subject(:file)          { build :git_committed_file }
   let(:root)              { create :file, :root, repository: repository }
   let(:repository)        { build :repository }
   let(:create_revision)   { create :git_revision, repository: repository }

--- a/spec/models/version_control/files/committed_spec.rb
+++ b/spec/models/version_control/files/committed_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe VersionControl::Files::Staged, type: :model do
   subject(:file)          { build :committed_file }
   let(:root)              { create :file, :root, repository: repository }
   let(:repository)        { build :repository }
-  let(:create_revision)   { create :revision, repository: repository }
+  let(:create_revision)   { create :git_revision, repository: repository }
 
   it_should_behave_like 'being a file'
 

--- a/spec/models/version_control/revision_collection_spec.rb
+++ b/spec/models/version_control/revision_collection_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe VersionControl::RevisionCollection, type: :model do
     it                { is_expected.to be nil }
 
     context 'when a previous revision exists' do
-      before            { create :revision, repository: repository }
+      before            { create :git_revision, repository: repository }
       let(:last_commit) { repository.rugged_repository.last_commit }
 
       it do

--- a/spec/models/version_control/revision_diff_spec.rb
+++ b/spec/models/version_control/revision_diff_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
     let!(:file)           { create :file, parent: root }
     let(:root)            { create :file, :root, repository: repository }
     let(:differentiator)  { repository.revisions.last }
-    before { create :revision, repository: repository }
+    before { create :git_revision, repository: repository }
 
     it { is_expected.to be_a VersionControl::FileDiff }
 
@@ -248,7 +248,7 @@ RSpec.describe VersionControl::RevisionDiff, type: :model do
     end
 
     context 'when base is revision' do
-      before      { create :revision, repository: repository }
+      before      { create :git_revision, repository: repository }
       let(:base)  { repository.revisions.last }
 
       it_should_behave_like 'not using repository locking' do

--- a/spec/models/version_control/revisions/committed_spec.rb
+++ b/spec/models/version_control/revisions/committed_spec.rb
@@ -5,11 +5,11 @@ require 'models/shared_examples/version_control/being_a_revision.rb'
 require 'models/shared_examples/version_control/repository_locking.rb'
 
 RSpec.describe VersionControl::Revisions::Committed, type: :model do
-  subject(:revision)  { create :revision }
+  subject(:revision)  { create :git_revision }
   let(:repository)    { revision.repository }
 
   it_should_behave_like 'being a revision' do
-    subject!(:revision) { create :revision }
+    subject!(:git_revision) { create :git_revision }
   end
 
   describe 'attributes' do

--- a/spec/models/version_control/revisions/drafted_spec.rb
+++ b/spec/models/version_control/revisions/drafted_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe VersionControl::Revisions::Drafted, type: :model do
     end
 
     context 'when previous commits have occurred' do
-      before { create :revision, repository: repository }
+      before { create :git_revision, repository: repository }
 
       it 'changes last_commit' do
         expect { method }
@@ -113,7 +113,7 @@ RSpec.describe VersionControl::Revisions::Drafted, type: :model do
     context 'when commit occurs after revision is built' do
       before { revision }
       before { allow(revision).to receive(:valid?).and_return true }
-      before { create :revision, repository: repository }
+      before { create :git_revision, repository: repository }
 
       it 'raises Rugged::ObjectError' do
         expect { method }.to raise_error(

--- a/spec/models/version_control/revisions/staged_spec.rb
+++ b/spec/models/version_control/revisions/staged_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe VersionControl::Revisions::Staged, type: :model do
     end
 
     context 'when a previous revision exists' do
-      before        { create :revision, repository: repository }
+      before        { create :git_revision, repository: repository }
       let(:message) { '1st revision' }
       let(:author)  { { name: 'User', email: '1' } }
 

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -94,9 +94,9 @@ RSpec.describe 'file_infos/index', type: :view do
     let(:revision_diff2)  { instance_double VersionControl::RevisionDiff }
     let(:revision_diff3)  { instance_double VersionControl::RevisionDiff }
     let(:revisions)       { [revision1, revision2, revision3] }
-    let(:revision1)       { create :revision, repository: repository }
-    let(:revision2)       { create :revision, repository: repository }
-    let(:revision3)       { create :revision, repository: repository }
+    let(:revision1)       { create :git_revision, repository: repository }
+    let(:revision2)       { create :git_revision, repository: repository }
+    let(:revision3)       { create :git_revision, repository: repository }
     let(:repository)      { build :repository }
     let(:file)            { build :file, name: 'File' }
     let(:ancestors)       { [] }

--- a/spec/views/revisions/index_spec.rb
+++ b/spec/views/revisions/index_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe 'revisions/index', type: :view do
   let(:repository)  { project.repository }
   let(:revisions)   { [revision1, revision2, revision3] }
   let(:revision1) do
-    create :revision, repository: repository, author: authors[0]
+    create :git_revision, repository: repository, author: authors[0]
   end
   let(:revision2) do
-    create :revision, repository: repository, author: authors[1]
+    create :git_revision, repository: repository, author: authors[1]
   end
   let(:revision3) do
-    create :revision, repository: repository, author: authors[2]
+    create :git_revision, repository: repository, author: authors[2]
   end
   let(:authors) { create_list :user, 3 }
 
@@ -76,13 +76,13 @@ RSpec.describe 'revisions/index', type: :view do
     let!(:root)       { create :file, :root, repository: project.repository }
     let!(:file1)      { create :file, name: 'File1', parent: root }
     let!(:folder)     { create :file, :folder, name: 'Folder', parent: root }
-    let!(:revision1)  { create :revision, repository: project.repository }
+    let!(:revision1)  { create :git_revision, repository: project.repository }
     let!(:file2)      { create :file, name: 'File2', parent: root }
     before            { file1.update(parent_id: folder.id) }
-    let!(:revision2)  { create :revision, repository: project.repository }
+    let!(:revision2)  { create :git_revision, repository: project.repository }
     before            { file2.destroy }
     before            { file1.update(modified_time: Time.zone.now) }
-    let!(:revision3)  { create :revision, repository: project.repository }
+    let!(:revision3)  { create :git_revision, repository: project.repository }
 
     before { assign(:revisions, [revision3, revision2, revision1]) }
 


### PR DESCRIPTION
Create Revision model.
Create CommittedFile model to associate revisions with file resources and snapshots of files.
Add Project.revisions#create_draft_and_commit_files! method to draft a new revision and commit all currently staged files.