### PR TITLE
Validate: Current snapshot must belong to snapshotable

### DIFF
--- a/app/models/concerns/snapshotable.rb
+++ b/app/models/concerns/snapshotable.rb
@@ -13,6 +13,9 @@ module Snapshotable
 
     before_save :clear_snapshot, if: :deleted?
     after_save :snapshot!, if: :saved_changes_to_metadata?, unless: :deleted?
+
+    validate :current_snapshot_must_belong_to_snapshotable,
+             if: :current_snapshot
   end
 
   private
@@ -33,6 +36,12 @@ module Snapshotable
   # Clear the current snapshot association
   def clear_snapshot
     self.current_snapshot = nil
+  end
+
+  # Validate that current snapshot is associated with this snapshotable
+  def current_snapshot_must_belong_to_snapshotable
+    return if current_snapshot.snapshotable_id == id
+    errors.add(:current_snapshot, "must belong to this #{model_name}")
   end
 
   # Has any of the metadata been saved changes to?

--- a/app/models/file_resource/snapshot.rb
+++ b/app/models/file_resource/snapshot.rb
@@ -13,6 +13,9 @@ class FileResource
       raise ActiveRecord::ReadOnlyRecord
     end
 
+    # Attributes
+    alias_attribute :snapshotable_id, :file_resource_id
+
     # Validations
     validates :file_resource_id,  presence: true
     validates :name,              presence: true

--- a/spec/integrations/file_resources/google_drive_spec.rb
+++ b/spec/integrations/file_resources/google_drive_spec.rb
@@ -11,8 +11,9 @@ RSpec.describe FileResources::GoogleDrive, type: :model do
   let(:external_id) { 'id' }
 
   it_should_behave_like 'including snapshotable integration' do
-    let(:file) { build :file_resources_google_drive }
-    let(:snapshotable) { file }
+    let(:file)                    { build :file_resources_google_drive }
+    let(:snapshotable)            { file }
+    let(:snapshotable_model_name) { 'FileResources::GoogleDrive' }
   end
 
   it_should_behave_like 'including stageable integration' do

--- a/spec/integrations/shared_examples/including_snapshotable_integration.rb
+++ b/spec/integrations/shared_examples/including_snapshotable_integration.rb
@@ -1,48 +1,63 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples 'including snapshotable integration' do
-  let(:create)        { snapshotable.save }
-  let(:from_database) { snapshotable.class.find(snapshotable.id) }
+  describe 'callbacks' do
+    let(:create)        { snapshotable.save }
+    let(:from_database) { snapshotable.class.find(snapshotable.id) }
 
-  describe 'create' do
-    it { expect { create }.to change { FileResource::Snapshot.count }.by(1) }
-  end
-
-  describe 'update' do
-    subject(:method)    { from_database.update(name: 'name', mime_type: 'doc') }
-    before              { create }
-    it { expect { method }.to change { FileResource::Snapshot.count }.by(1) }
-  end
-
-  describe 'is_deleted = true' do
-    subject(:method)    { from_database.update(is_deleted: true) }
-    before              { create }
-    it { expect { method }.not_to(change { FileResource::Snapshot.count }) }
-    it { expect { method }.not_to(change { FileResource.count }) }
-  end
-
-  describe 'when snapshot already exists' do
-    let!(:original_name)        { snapshotable.name }
-    let(:original_snapshot_id)  { snapshotable.snapshots.first.id }
-
-    before do
-      # create a snapshot with original attributes
-      snapshotable.save
-
-      # create a snapshot with new name
-      snapshotable.update(name: 'new-name')
-
-      # reset attributes to original ones
-      snapshotable.name = original_name
+    describe 'create' do
+      it { expect { create }.to change { FileResource::Snapshot.count }.by(1) }
     end
 
-    it 'does not create a new snapshot' do
-      expect { snapshotable.save }.not_to change(FileResource::Snapshot, :count)
+    describe 'update' do
+      subject(:method)  { from_database.update(name: 'name', mime_type: 'doc') }
+      before            { create }
+      it { expect { method }.to change { FileResource::Snapshot.count }.by(1) }
     end
 
-    it 'sets current snapshot ID to the existing snapshot' do
-      expect { snapshotable.save }
-        .to change(snapshotable, :current_snapshot_id).to(original_snapshot_id)
+    describe 'is_deleted = true' do
+      subject(:method)    { from_database.update(is_deleted: true) }
+      before              { create }
+      it { expect { method }.not_to(change { FileResource::Snapshot.count }) }
+      it { expect { method }.not_to(change { FileResource.count }) }
+    end
+
+    describe 'when snapshot already exists' do
+      let!(:original_name)        { snapshotable.name }
+      let(:original_snapshot_id)  { snapshotable.snapshots.first.id }
+
+      before do
+        # create a snapshot with original attributes
+        snapshotable.save
+
+        # create a snapshot with new name
+        snapshotable.update(name: 'new-name')
+
+        # reset attributes to original ones
+        snapshotable.name = original_name
+      end
+
+      it 'does not create a new snapshot' do
+        expect { snapshotable.save }
+          .not_to change(FileResource::Snapshot, :count)
+      end
+
+      it 'sets current snapshot ID to the existing snapshot' do
+        expect { snapshotable.save }
+          .to change(snapshotable, :current_snapshot_id)
+          .to(original_snapshot_id)
+      end
+    end
+  end
+
+  describe 'validation: current snapshot must belong to snapshotable' do
+    let(:other_snapshot)  { create :file_resource_snapshot }
+    before                { snapshotable.current_snapshot = other_snapshot }
+
+    it 'adds error: must belong to snapshotable' do
+      expect(snapshotable).to be_invalid
+      expect(snapshotable.errors[:current_snapshot])
+        .to contain_exactly "must belong to this #{snapshotable_model_name}"
     end
   end
 end

--- a/spec/integrations/shared_examples/including_stageable_integration.rb
+++ b/spec/integrations/shared_examples/including_stageable_integration.rb
@@ -22,7 +22,8 @@ RSpec.shared_examples 'including stageable integration' do
   end
 
   describe 'parent is updated' do
-    let(:new_parent) { parent.dup }
+    let(:new_parent) { described_class.new(attributes) }
+    let(:attributes) { parent.dup.attributes.except('current_snapshot_id') }
 
     before do
       # Create new parent with staged projects

--- a/spec/models/file_resource/snapshot_spec.rb
+++ b/spec/models/file_resource/snapshot_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe FileResource::Snapshot, type: :model do
     end
   end
 
+  describe 'attributes' do
+    it { is_expected.to respond_to(:snapshotable_id) }
+  end
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:file_resource_id) }
     it { is_expected.to validate_presence_of(:name) }

--- a/spec/models/shared_examples/being_a_file_resource.rb
+++ b/spec/models/shared_examples/being_a_file_resource.rb
@@ -93,7 +93,9 @@ RSpec.shared_examples 'being a file resource' do
       let(:parent) do
         described_class.create!(attributes.merge(external_id: 'parent'))
       end
-      let(:attributes) { file_resource.dup.attributes.except('id') }
+      let(:attributes) do
+        file_resource.dup.attributes.except('id', 'current_snapshot_id')
+      end
 
       before do
         file_resource.update(parent: parent)


### PR DESCRIPTION
When setting a current snapshot for a snapshotable object, the current snapshot must belong to the snapshotable object.