### PR TITLE
Implement DB-backed File Diffs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,8 @@ gem 'filelock'
 gem 'rollbar', '~> 2.15'
 # Paperclip for attachments
 gem 'paperclip', '~> 5.2'
+# ActiveRecord-Import for bulk creation of records
+gem 'activerecord-import', '~> 0.22'
 
 group :development, :test do
   # We will use pry rails as our console
@@ -75,8 +77,6 @@ group :development, :test do
   gem 'factory_girl_rails', '~> 4.8'
   # Quickly generate fake names, urls, etc
   gem 'faker', '~> 1.8'
-  # ActiveRecord-Import for bulk creation of records
-  gem 'activerecord-import', '~> 0.22'
 end
 
 group :development do

--- a/app/models/committed_file.rb
+++ b/app/models/committed_file.rb
@@ -15,6 +15,17 @@ class CommittedFile < ApplicationRecord
             }
   validate :file_resource_snapshot_belongs_to_file_resource
 
+  # Scopes
+  # Committed files where snapshot ID changed from revision 1 to revision 2
+  scope :where_snapshot_changed_between_revisions, lambda { |rev1, rev2|
+    select(:file_resource_id,
+           :file_resource_snapshot_id,
+           'min(revision_id) AS revision_id')
+      .where(revision_id: [rev1, rev2].compact)
+      .group(:file_resource_id, :file_resource_snapshot_id)
+      .having('count(*) = 1')
+  }
+
   # Execute INSERT query based on the SELECT query
   # Order of columns must match order of select statements.
   # For example:

--- a/app/models/committed_file.rb
+++ b/app/models/committed_file.rb
@@ -25,6 +25,12 @@ class CommittedFile < ApplicationRecord
       .group(:file_resource_id, :file_resource_snapshot_id)
       .having('count(*) = 1')
   }
+  scope :distinct_file_resources_between_revisions, lambda { |rev1, rev2|
+    select('DISTINCT ON (committed_files.file_resource_id) ' \
+           'committed_files.file_resource_id')
+      .where(revision_id: [rev1, rev2].compact)
+      .order(:file_resource_id, revision_id: :desc)
+  }
 
   # Execute INSERT query based on the SELECT query
   # Order of columns must match order of select statements.

--- a/app/models/file_diff.rb
+++ b/app/models/file_diff.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Class for handling diffing of File Resources
+class FileDiff < ApplicationRecord
+  # Associations
+  belongs_to :revision
+  belongs_to :file_resource
+  belongs_to :current_snapshot, class_name: 'FileResource::Snapshot',
+                                optional: true
+  belongs_to :previous_snapshot, class_name: 'FileResource::Snapshot',
+                                 optional: true
+
+  # Validations
+  # Either current or previous snapshot must be present
+  validates :current_snapshot_id, presence: true, unless: :previous_snapshot_id
+  validates :previous_snapshot_id, presence: true, unless: :current_snapshot_id
+end

--- a/app/models/file_diff.rb
+++ b/app/models/file_diff.rb
@@ -14,4 +14,17 @@ class FileDiff < ApplicationRecord
   # Either current or previous snapshot must be present
   validates :current_snapshot_id, presence: true, unless: :previous_snapshot_id
   validates :previous_snapshot_id, presence: true, unless: :current_snapshot_id
+
+  def added?
+    previous_snapshot_id.nil?
+  end
+
+  def deleted?
+    current_snapshot_id.nil?
+  end
+
+  def updated?
+    # Neither added nor deleted
+    !(added? || deleted?)
+  end
 end

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -7,6 +7,7 @@ class Revision < ApplicationRecord
   belongs_to :parent, class_name: 'Revision', optional: true, autosave: false
   belongs_to :author, class_name: 'Profiles::User'
   has_many :committed_files, dependent: :destroy
+  has_many :file_diffs, dependent: :destroy
 
   # attributes
   attr_readonly :project_id, :parent_id, :author_id

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -12,11 +12,8 @@ class Revision < ApplicationRecord
   attr_readonly :project_id, :parent_id, :author_id
 
   # Validations
-  # Require title and summary for published revisions
-  with_options if: :published? do
-    validates :title, presence: true
-    validates :summary, presence: true
-  end
+  # Require title for published revisions
+  validates :title, presence: true, if: :published?
 
   validate :parent_must_belong_to_same_project, if: :parent_id
   validate :can_only_have_one_revision_with_parent, if: :parent_id

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -27,6 +27,7 @@ class Revision < ApplicationRecord
             parent: project.published_revisions.last,
             author: author)
       .tap(&:commit_all_files_staged_in_project)
+      .tap(&:generate_diffs)
   end
 
   # Take ID and current snapshot ID of all (non-root) file resources currently
@@ -38,6 +39,11 @@ class Revision < ApplicationRecord
              .with_current_snapshot             # ignore files without snapshot
              .select(id, :id, :current_snapshot_id)
     )
+  end
+
+  # Calculate and cache file diffs from parent revision to self
+  def generate_diffs
+    FileDiffsCalculator.new(revision: self).cache_diffs!
   end
 
   def published?

--- a/app/models/revision/file_ancestry_tree.rb
+++ b/app/models/revision/file_ancestry_tree.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+class Revision
+  # Generate the ancestor tree for a set of files at a given revision
+  class FileAncestryTree
+    # Initialize and generate tree
+    def self.generate(revision:, file_ids:, depth:)
+      tree = new(revision: revision, file_ids: file_ids)
+      tree.recursively_load_parents(depth: depth)
+      tree
+    end
+
+    def initialize(revision:, file_ids:)
+      self.revision = revision
+      initialize_tree(file_ids)
+    end
+
+    # Return the ancestor names for a given file ID
+    def ancestors_names_for(file_id, depth:)
+      ancestor_names = []
+      file = find(file_id)
+
+      (1..depth).each do
+        file = find(file[:parent])
+        break unless file.present?
+
+        ancestor_names << file[:name]
+      end
+
+      ancestor_names
+    end
+
+    # Load parent records for all nil entries
+    def load_parents
+      return unless nil_entries.any?
+
+      parents = fetch_records_for(nil_entries.keys)
+
+      # add parents fetched from database
+      add_entries(parents)
+
+      # set nil entries to false (these records were not found)
+      update_entries(nil_entries.keys, false)
+
+      # add parents' parent IDs as nil entries (these records will be fetched
+      # next time)
+      add_nil_entries(parents.map { |parent| parent[:parent] }.compact)
+    end
+
+    # Recursively call #load_parents depth number of times
+    def recursively_load_parents(depth:)
+      depth.times do
+        load_parents
+      end
+    end
+
+    private
+
+    attr_accessor :revision, :tree
+
+    # Add entries, must be an array of hashes in format:
+    # {id: _, name: _, parent: _}
+    def add_entries(entries)
+      new_entries =
+        entries
+        .map { |hash| [hash[:id], hash.slice(:name, :parent)] }
+        .to_h
+      tree.merge!(new_entries)
+    end
+
+    # Find an entry by ID or return nil
+    def find(id)
+      tree[id] || nil
+    end
+
+    # Set up tree with nil entrie
+    def initialize_tree(file_ids)
+      self.tree = {}
+      add_nil_entries(file_ids)
+    end
+
+    # Return all hashes with nil value
+    def nil_entries
+      tree.select { |_, entry| entry.nil? }
+    end
+
+    # Add IDs with nil value
+    def add_nil_entries(ids)
+      nil_entry_hash = ids.map { |id| [id, nil] }.to_h
+      tree.reverse_merge!(nil_entry_hash)
+    end
+
+    # Update entries of IDs with new value
+    def update_entries(ids, new_value)
+      updated_entries = ids.map { |id| [id, new_value] }.to_h
+      tree.merge!(updated_entries)
+    end
+
+    # Fetch file snapshot records for the given IDs
+    def fetch_records_for(ids)
+      CommittedFile
+        .connection
+        .select_all(distinct_file_resources_between_revisions_with_ids(ids))
+        .rows.map { |id, name, parent| { id: id, name: name, parent: parent } }
+    end
+
+    # ActiveRecord query for distinct file resources between revision and its
+    # parent revision for a given array of IDs
+    def distinct_file_resources_between_revisions_with_ids(ids)
+      CommittedFile
+        .distinct_file_resources_between_revisions(revision, revision.parent_id)
+        .joins(:file_resource_snapshot)
+        .select('file_resource_snapshots.name',
+                'file_resource_snapshots.parent_id')
+        .where(file_resource_id: ids)
+    end
+  end
+end

--- a/app/models/revision/file_diffs_calculator.rb
+++ b/app/models/revision/file_diffs_calculator.rb
@@ -23,12 +23,33 @@ class Revision
 
     attr_accessor :revision
 
+    # Number of ancestors to load for each diff
+    def ancestor_depth
+      3
+    end
+
+    # Return an array of ancestors names for a given diff, up to default depth
+    def ancestors_names_for(diff)
+      ancestry_tree.ancestors_names_for(diff['file_resource_id'],
+                                        depth: ancestor_depth)
+    end
+
+    # Return (or load) ancestry tree for diffs
+    def ancestry_tree
+      @ancestry_tree ||=
+        FileAncestryTree.generate(
+          revision: revision,
+          file_ids: raw_diffs.map { |diff| diff['file_resource_id'] },
+          depth: ancestor_depth
+        )
+    end
+
     # Calculate diffs by converting raw diffs to attribute hashes and adding
     # ancestor names up to default depth
     def calculate_diffs
       raw_diffs.map do |raw_diff|
         raw_diff_to_diff(raw_diff)
-          .merge('first_three_ancestors' => [])
+          .merge('first_three_ancestors' => ancestors_names_for(raw_diff))
       end
     end
 

--- a/app/models/revision/file_diffs_calculator.rb
+++ b/app/models/revision/file_diffs_calculator.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class Revision
+  # Calculate and cache file diffs from one revision to another
+  class FileDiffsCalculator
+    # Initialize a new instance of FileDiffCalculator to calculate file diffs
+    # between revision and its parent revision
+    def initialize(revision:)
+      self.revision = revision
+    end
+
+    # Persist diffs to database in FileDiffs table
+    def cache_diffs!
+      FileDiff.import(diffs, validate: false)
+    end
+
+    # Return diffs as attribute hashes
+    def diffs
+      @diffs ||= calculate_diffs
+    end
+
+    private
+
+    attr_accessor :revision
+
+    # Calculate diffs by converting raw diffs to attribute hashes and adding
+    # ancestor names up to default depth
+    def calculate_diffs
+      raw_diffs.map do |raw_diff|
+        raw_diff_to_diff(raw_diff)
+          .merge('first_three_ancestors' => [])
+      end
+    end
+
+    # Return committed files where snapshot changed from revision parent to
+    # revision
+    def committed_files_where_snapshot_changed
+      CommittedFile
+        .where_snapshot_changed_between_revisions(revision, revision.parent_id)
+    end
+
+    # Parse a single raw diff to an attribute diff
+    def raw_diff_to_diff(raw_diff)
+      raw_diff
+        .slice('file_resource_id')
+        .merge(
+          'revision_id' => revision.id,
+          'current_snapshot_id' =>
+            snapshot_id_from_raw_diff(raw_diff, revision.id),
+          'previous_snapshot_id' =>
+            snapshot_id_from_raw_diff(raw_diff, revision.parent_id)
+        )
+    end
+
+    # Return committed files where snapshot changed from revision parent to
+    # revision grouped into a single row for every file resource
+    def raw_diffs
+      @raw_diffs ||=
+        FileDiff.select(:file_resource_id, 'json_agg(subquery) AS snapshots')
+                .from(committed_files_where_snapshot_changed)
+                .group(:file_resource_id)
+                .reorder('subquery.file_resource_id')
+                .map(&:attributes)
+    end
+
+    # Retrieve the file resource snapshot from the given raw diff and revision
+    def snapshot_id_from_raw_diff(raw_diff, revision_id)
+      raw_diff['snapshots']
+        .find { |snapshots| snapshots['revision_id'] == revision_id }
+        &.fetch('file_resource_snapshot_id', nil)
+        &.to_i
+    end
+  end
+end

--- a/db/migrate/20180227150638_create_file_diffs.rb
+++ b/db/migrate/20180227150638_create_file_diffs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Create FileDiffs table for storing pre-generated file diffs (so that we do not
+# have to create them at run-time)
+class CreateFileDiffs < ActiveRecord::Migration[5.1]
+  def change
+    create_table :file_diffs do |t|
+      t.belongs_to :revision, foreign_key: true, null: false, index: false
+      t.belongs_to :file_resource, foreign_key: true, null: false
+      t.belongs_to :current_snapshot,
+                   foreign_key: { to_table: :file_resource_snapshots },
+                   null: true
+      t.belongs_to :previous_snapshot,
+                   foreign_key: { to_table: :file_resource_snapshots },
+                   null: true
+      t.text :first_three_ancestors, array: true, null: false
+
+      # Do not allow duplicate file resources in the same revision
+      t.index %i[revision_id file_resource_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180218233707) do
+ActiveRecord::Schema.define(version: 20180227150638) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,6 +52,20 @@ ActiveRecord::Schema.define(version: 20180218233707) do
     t.string "delayed_reference_type"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
     t.index ["queue"], name: "index_delayed_jobs_on_queue"
+  end
+
+  create_table "file_diffs", force: :cascade do |t|
+    t.bigint "revision_id", null: false
+    t.bigint "file_resource_id", null: false
+    t.bigint "current_snapshot_id"
+    t.bigint "previous_snapshot_id"
+    t.text "first_three_ancestors", null: false, array: true
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["current_snapshot_id"], name: "index_file_diffs_on_current_snapshot_id"
+    t.index ["file_resource_id"], name: "index_file_diffs_on_file_resource_id"
+    t.index ["previous_snapshot_id"], name: "index_file_diffs_on_previous_snapshot_id"
+    t.index ["revision_id", "file_resource_id"], name: "index_file_diffs_on_revision_id_and_file_resource_id", unique: true
   end
 
   create_table "file_resource_snapshots", force: :cascade do |t|
@@ -158,6 +172,10 @@ ActiveRecord::Schema.define(version: 20180218233707) do
   add_foreign_key "committed_files", "file_resource_snapshots"
   add_foreign_key "committed_files", "file_resources"
   add_foreign_key "committed_files", "revisions"
+  add_foreign_key "file_diffs", "file_resource_snapshots", column: "current_snapshot_id"
+  add_foreign_key "file_diffs", "file_resource_snapshots", column: "previous_snapshot_id"
+  add_foreign_key "file_diffs", "file_resources"
+  add_foreign_key "file_diffs", "revisions"
   add_foreign_key "file_resource_snapshots", "file_resources", column: "parent_id"
   add_foreign_key "file_resources", "file_resource_snapshots", column: "current_snapshot_id"
   add_foreign_key "file_resources", "file_resources", column: "parent_id"

--- a/lib/tasks/performance/generate_diffs_for_origin_revision.rake
+++ b/lib/tasks/performance/generate_diffs_for_origin_revision.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+desc 'Performance: Generate diffs for origin revision'
+namespace :performance do
+  task generate_diffs_for_origin_revision:
+       ['generate_diffs_for_origin_revision:all']
+
+  namespace :generate_diffs_for_origin_revision do
+    task all: %i[cleanup prepare test]
+  end
+end

--- a/lib/tasks/performance/generate_diffs_for_origin_revision/cleanup.rake
+++ b/lib/tasks/performance/generate_diffs_for_origin_revision/cleanup.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+desc 'Performance: Generate diffs for origin revision: Cleanup'
+namespace :performance do
+  namespace :generate_diffs_for_origin_revision do
+    task cleanup: :test_environment do
+      puts 'Cleanup: FileDiff'
+      FileDiff.delete_all
+      puts 'Cleanup: CommittedFile'
+      CommittedFile.delete_all
+      puts 'Cleanup: Reset current snapshot'
+      FileResource.in_batches(of: 10_000).each_with_index do |relation, n|
+        relation.update_all(current_snapshot_id: nil)
+        puts "Progress: #{(n + 1)}x10000"
+      end
+      puts 'Cleanup: Snapshot'
+      FileResource::Snapshot.delete_all
+      puts 'Cleanup: FileResource'
+      FileResource.in_batches(of: 10_000).each_with_index do |relation, n|
+        relation.delete_all
+        puts "Progress: #{(n + 1)}x10000"
+      end
+      puts 'Cleanup: Revision'
+      Revision.delete_all
+      puts 'Cleanup: Project'
+      Project.delete_all
+
+      puts 'Cleanup...Done'
+    end
+  end
+end

--- a/lib/tasks/performance/generate_diffs_for_origin_revision/prepare.rake
+++ b/lib/tasks/performance/generate_diffs_for_origin_revision/prepare.rake
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'factory_girl'
+
+desc 'Performance: Generate diffs for origin revision: Prepare'
+namespace :performance do
+  namespace :generate_diffs_for_origin_revision do
+    task prepare: :test_environment do
+      puts 'Preparing database'
+
+      snapshot_id = FactoryGirl.create(:file_resource_snapshot).id
+      batch_size = 1_000
+      columns = %i[provider_id external_id mime_type name content_version
+                   current_snapshot_id]
+
+      10.times do |n|
+        rows = []
+        batch_size.times do |batch_n|
+          rows << [0, (batch_n + batch_size * n).to_s, 'doc', 'name', '1',
+                   snapshot_id]
+        end
+        FileResource.import columns, rows, validate: false
+        puts "Progress: #{(n + 1) * batch_size} records created"
+      end
+
+      puts 'Creating revision with all file resources committed'
+      revision = FactoryGirl.create(:revision)
+
+      columns = %i[file_resource_id file_resource_snapshot_id revision_id]
+      rows = FileResource.all.pluck(:id, :current_snapshot_id)
+                         .map { |v| v.push(revision.id) }
+      CommittedFile.import columns, rows, validate: false
+
+      puts 'Preparing database...Done'
+    end
+  end
+end

--- a/lib/tasks/performance/generate_diffs_for_origin_revision/test.rake
+++ b/lib/tasks/performance/generate_diffs_for_origin_revision/test.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+desc 'Performance: Generate diffs for origin revision: Test'
+namespace :performance do
+  namespace :generate_diffs_for_origin_revision do
+    task test: :test_environment do
+      revision = Revision.last
+
+      puts "Benchmarking with #{revision.committed_files.count} records"
+
+      time = Benchmark.realtime { revision.generate_diffs }
+
+      puts "Completed in #{time} seconds"
+    end
+  end
+end

--- a/lib/tasks/performance/generate_diffs_for_revision_with_parent.rake
+++ b/lib/tasks/performance/generate_diffs_for_revision_with_parent.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+desc 'Performance: Generate diffs for revision with parent'
+namespace :performance do
+  task generate_diffs_for_revision_with_parent:
+       ['generate_diffs_for_revision_with_parent:all']
+
+  namespace :generate_diffs_for_revision_with_parent do
+    task all: %i[cleanup prepare test]
+  end
+end

--- a/lib/tasks/performance/generate_diffs_for_revision_with_parent/cleanup.rake
+++ b/lib/tasks/performance/generate_diffs_for_revision_with_parent/cleanup.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+desc 'Performance: Generate diffs for revision with parent: Cleanup'
+namespace :performance do
+  namespace :generate_diffs_for_revision_with_parent do
+    task cleanup: :test_environment do
+      puts 'Cleanup: FileDiff'
+      FileDiff.delete_all
+      puts 'Cleanup: CommittedFile'
+      CommittedFile.delete_all
+      puts 'Cleanup: Reset current snapshot'
+      FileResource.in_batches(of: 10_000).each_with_index do |relation, n|
+        relation.update_all(current_snapshot_id: nil)
+        puts "Progress: #{(n + 1)}x10000"
+      end
+      puts 'Cleanup: Snapshot'
+      FileResource::Snapshot.delete_all
+      puts 'Cleanup: FileResource'
+      FileResource.in_batches(of: 10_000).each_with_index do |relation, n|
+        relation.delete_all
+        puts "Progress: #{(n + 1)}x10000"
+      end
+      puts 'Cleanup: Revision'
+      Revision.delete_all
+      puts 'Cleanup: Project'
+      Project.delete_all
+
+      puts 'Cleanup...Done'
+    end
+  end
+end

--- a/lib/tasks/performance/generate_diffs_for_revision_with_parent/prepare.rake
+++ b/lib/tasks/performance/generate_diffs_for_revision_with_parent/prepare.rake
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'factory_girl'
+
+desc 'Performance: Generate diffs for revision with parent: Prepare'
+namespace :performance do
+  namespace :generate_diffs_for_revision_with_parent do
+    task prepare: :test_environment do
+      puts 'Preparing database'
+
+      create_file_resources
+
+      puts 'Creating revision with all file resources committed'
+      create_revision_with_all_file_resources_committed
+
+      puts 'Updating 100 file resources'
+      FileResource.first(100).each do |file|
+        file.update(name: 'updated')
+      end
+
+      puts 'Creating 2nd revision with all file resources committed'
+      create_revision_with_all_file_resources_committed(parent: Revision.last)
+
+      puts 'Preparing database...Done'
+    end
+  end
+end
+
+# rubocop:disable Metrics/MethodLength
+def create_file_resources
+  snapshot_id = FactoryGirl.create(:file_resource_snapshot).id
+  batch_size = 1_000
+  columns = %i[provider_id external_id mime_type name content_version
+               current_snapshot_id]
+
+  10.times do |n|
+    rows = []
+    batch_size.times do |batch_n|
+      rows << [0, (batch_n + batch_size * n).to_s, 'doc', 'name', '1',
+               snapshot_id]
+    end
+    FileResource.import columns, rows, validate: false
+    puts "Progress: #{(n + 1) * batch_size} records created"
+  end
+end
+# rubocop:enable Metrics/MethodLength
+
+def create_revision_with_all_file_resources_committed(parent: nil)
+  revision = FactoryGirl.create(:revision, parent: parent)
+
+  columns = %i[file_resource_id file_resource_snapshot_id revision_id]
+  rows = FileResource.all.pluck(:id, :current_snapshot_id)
+                     .map { |v| v.push(revision.id) }
+  CommittedFile.import columns, rows, validate: false
+end

--- a/lib/tasks/performance/generate_diffs_for_revision_with_parent/test.rake
+++ b/lib/tasks/performance/generate_diffs_for_revision_with_parent/test.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+desc 'Performance: Generate diffs for revision with parent: Test'
+namespace :performance do
+  namespace :generate_diffs_for_revision_with_parent do
+    task test: :test_environment do
+      revision = Revision.last
+
+      puts "Benchmarking with #{revision.committed_files.count} records"
+
+      time = Benchmark.realtime { revision.generate_diffs }
+
+      puts "Completed in #{time} seconds"
+    end
+  end
+end

--- a/spec/factories/file_diffs.rb
+++ b/spec/factories/file_diffs.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :file_diff do
+    revision
+    file_resource
+    current_snapshot { file_resource.current_snapshot }
+    first_three_ancestors { Faker::Lorem.words(3) }
+
+    trait :with_previous_snapshot do
+      association :previous_snapshot, factory: :file_resource_snapshot
+    end
+  end
+end

--- a/spec/integrations/revision/file_diffs_calculator_spec.rb
+++ b/spec/integrations/revision/file_diffs_calculator_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+RSpec.describe Revision::FileDiffsCalculator, type: :model do
+  subject(:calculator)  { described_class.new(revision: revision) }
+  let(:revision)        { create :revision, :with_parent }
+  let(:parent_revision) { revision.parent }
+
+  describe '#cache_diffs!' do
+    let(:diffs) { FileDiff.where(revision: revision) }
+    let(:diff1) { diffs.find_by(file_resource_id: f1.id) }
+    let(:diff2) { diffs.find_by(file_resource_id: f2.id) }
+    let(:diff3) { diffs.find_by(file_resource_id: f3.id) }
+    let(:diff4) { diffs.find_by(file_resource_id: f4.id) }
+    let(:diff5) { diffs.find_by(file_resource_id: f5.id) }
+    let(:diff6) { diffs.find_by(file_resource_id: f6.id) }
+    let(:diff7) { diffs.find_by(file_resource_id: f7.id) }
+    let(:diff8) { diffs.find_by(file_resource_id: f8.id) }
+    let(:diff9) { diffs.find_by(file_resource_id: f9.id) }
+
+    let(:f1) { create :file_resource, name: 'f1' }
+    let(:f2) { create :file_resource, name: 'f2', parent: f1 }
+    let(:f3) { create :file_resource, name: 'f3', parent: f2 }
+    let(:f4) { create :file_resource, name: 'f4', parent: f3 }
+    let(:f5) { create :file_resource, name: 'f5', parent: f4 }
+    let(:f6) { create :file_resource, name: 'f6' }
+    let(:f7) { create :file_resource, name: 'f7', parent: f6 }
+    let(:f8) { create :file_resource, name: 'f8', parent: f2 }
+    let(:f9) { create :file_resource, name: 'f9', parent: f8 }
+
+    before do
+      # committed files in parent revision
+      [f1, f2, f3, f4, f5, f6, f7].each do |file|
+        create :committed_file, revision: parent_revision, file_resource: file
+      end
+
+      # update parents of f3 and f6
+      f3.update!(parent: f6)
+      f6.update!(parent: f2)
+
+      # committed files in current revision
+      [f1, f2, f3, f6, f7, f8, f9].each do |file|
+        create :committed_file, revision: revision, file_resource: file
+      end
+
+      # calculate and cache diffs!
+      calculator.cache_diffs!
+    end
+
+    it 'has diffs for f3, f4, f5, f6, f8, f9' do
+      expect(diffs.map(&:file_resource_id))
+        .to match_array [f3, f4, f5, f6, f8, f9].map(&:id)
+
+      expect(diff3).to be_updated
+      expect(diff4).to be_deleted
+      expect(diff5).to be_deleted
+      expect(diff8).to be_added
+      expect(diff9).to be_added
+    end
+
+    context 'when revision is origin revision (parent is nil)' do
+      let(:revision)        { create :revision }
+      let(:parent_revision) { create :revision }
+
+      it 'has diffs for f1, f2, f3, f6, f7, f8, f9' do
+        expect(diffs.map(&:file_resource_id))
+          .to match_array [f1, f2, f3, f6, f7, f8, f9].map(&:id)
+
+        expect(diff1).to be_added
+        expect(diff2).to be_added
+        expect(diff3).to be_added
+        expect(diff6).to be_added
+        expect(diff7).to be_added
+        expect(diff8).to be_added
+        expect(diff9).to be_added
+      end
+    end
+  end
+end

--- a/spec/integrations/revision/file_diffs_calculator_spec.rb
+++ b/spec/integrations/revision/file_diffs_calculator_spec.rb
@@ -51,10 +51,19 @@ RSpec.describe Revision::FileDiffsCalculator, type: :model do
         .to match_array [f3, f4, f5, f6, f8, f9].map(&:id)
 
       expect(diff3).to be_updated
+      expect(diff3.first_three_ancestors).to eq %w[f6 f2 f1]
+
       expect(diff4).to be_deleted
+      expect(diff4.first_three_ancestors).to eq %w[f3 f6 f2]
+
       expect(diff5).to be_deleted
+      expect(diff5.first_three_ancestors).to eq %w[f4 f3 f6]
+
       expect(diff8).to be_added
+      expect(diff8.first_three_ancestors).to eq %w[f2 f1]
+
       expect(diff9).to be_added
+      expect(diff9.first_three_ancestors).to eq %w[f8 f2 f1]
     end
 
     context 'when revision is origin revision (parent is nil)' do
@@ -66,12 +75,25 @@ RSpec.describe Revision::FileDiffsCalculator, type: :model do
           .to match_array [f1, f2, f3, f6, f7, f8, f9].map(&:id)
 
         expect(diff1).to be_added
+        expect(diff1.first_three_ancestors).to eq %w[]
+
         expect(diff2).to be_added
+        expect(diff2.first_three_ancestors).to eq %w[f1]
+
         expect(diff3).to be_added
+        expect(diff3.first_three_ancestors).to eq %w[f6 f2 f1]
+
         expect(diff6).to be_added
+        expect(diff6.first_three_ancestors).to eq %w[f2 f1]
+
         expect(diff7).to be_added
+        expect(diff7.first_three_ancestors).to eq %w[f6 f2 f1]
+
         expect(diff8).to be_added
+        expect(diff8.first_three_ancestors).to eq %w[f2 f1]
+
         expect(diff9).to be_added
+        expect(diff9.first_three_ancestors).to eq %w[f8 f2 f1]
       end
     end
   end

--- a/spec/models/committed_file_spec.rb
+++ b/spec/models/committed_file_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe CommittedFile, type: :model do
     end
   end
 
+  describe 'scopes' do
+    it 'has scope: where_snapshot_changed_between_revisions' do
+      expect(described_class)
+        .to respond_to(:where_snapshot_changed_between_revisions)
+        .with(2).arguments
+    end
+  end
+
   describe 'validations' do
     subject(:file) { build :committed_file }
 

--- a/spec/models/file_diff_spec.rb
+++ b/spec/models/file_diff_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe FileDiff, type: :model do
+  subject(:diff) { build_stubbed :file_diff }
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:revision).autosave(false).dependent(false) }
+    it do
+      is_expected.to belong_to(:file_resource).autosave(false).dependent(false)
+    end
+    it do
+      is_expected
+        .to belong_to(:current_snapshot)
+        .class_name('FileResource::Snapshot')
+        .dependent(false)
+    end
+    it do
+      is_expected
+        .to belong_to(:previous_snapshot)
+        .class_name('FileResource::Snapshot')
+        .dependent(false)
+    end
+  end
+
+  describe 'validations' do
+    context 'when previous_snapshot_id is nil' do
+      before  { diff.previous_snapshot_id = nil }
+      it      { is_expected.to validate_presence_of(:current_snapshot_id) }
+    end
+
+    context 'when current_snapshot_id is nil' do
+      before  { diff.current_snapshot_id = nil }
+      it      { is_expected.to validate_presence_of(:previous_snapshot_id) }
+    end
+  end
+end

--- a/spec/models/file_diff_spec.rb
+++ b/spec/models/file_diff_spec.rb
@@ -33,4 +33,56 @@ RSpec.describe FileDiff, type: :model do
       it      { is_expected.to validate_presence_of(:previous_snapshot_id) }
     end
   end
+
+  describe '#added?' do
+    before { diff.current_snapshot_id = 123 }
+    before { diff.previous_snapshot_id = previous_snapshot_id }
+
+    context 'when previous_snapshot_id is nil' do
+      let(:previous_snapshot_id) { nil }
+      it { is_expected.to be_added }
+    end
+
+    context 'when previous_snapshot_id is not nil' do
+      let(:previous_snapshot_id) { 456 }
+      it { is_expected.not_to be_added }
+    end
+  end
+
+  describe '#updated?' do
+    let(:is_added) { false }
+    let(:is_deleted) { false }
+
+    before do
+      allow(diff).to receive(:added?).and_return is_added
+      allow(diff).to receive(:deleted?).and_return is_deleted
+    end
+
+    it { is_expected.to be_updated }
+
+    context 'when diff is added' do
+      let(:is_added) { true }
+      it { is_expected.not_to be_updated }
+    end
+
+    context 'when diff is deleted' do
+      let(:is_deleted) { true }
+      it { is_expected.not_to be_updated }
+    end
+  end
+
+  describe '#deleted?' do
+    before { diff.previous_snapshot_id = 123 }
+    before { diff.current_snapshot_id = current_snapshot_id }
+
+    context 'when current_snapshot_id is nil' do
+      let(:current_snapshot_id) { nil }
+      it { is_expected.to be_deleted }
+    end
+
+    context 'when current_snapshot_id is not nil' do
+      let(:current_snapshot_id) { 456 }
+      it { is_expected.not_to be_deleted }
+    end
+  end
 end

--- a/spec/models/revision/file_ancestry_tree_spec.rb
+++ b/spec/models/revision/file_ancestry_tree_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+RSpec.describe Revision::FileAncestryTree, type: :model do
+  subject(:ancestry_tree) do
+    Revision::FileAncestryTree.new(revision: revision, file_ids: file_ids)
+  end
+  let(:revision)  { instance_double Revision }
+  let(:file_ids)  { [1, 2, 3] }
+
+  describe '.generate(revision:, file_ids:, depth:)' do
+    subject(:generate)  { described_class.generate attributes }
+    let(:attributes)    { { revision: 'r', file_ids: 'ids', depth: 'd' } }
+    let(:new_tree)      { instance_double described_class }
+
+    before do
+      allow(described_class)
+        .to receive(:new)
+        .with(revision: 'r', file_ids: 'ids')
+        .and_return new_tree
+      allow(new_tree).to receive(:recursively_load_parents).with(depth: 'd')
+    end
+
+    it { is_expected.to eq new_tree }
+
+    it 'recursively_load_parents depth-times' do
+      expect(new_tree).to receive(:recursively_load_parents).with(depth: 'd')
+      generate
+    end
+  end
+
+  describe '#ancestors_names_for(file_id, depth:)' do
+    subject(:ancestors_names) do
+      ancestry_tree.send :ancestors_names_for, 1, depth: 3
+    end
+
+    let(:file)    { { name: 'file',     parent: 2 } }
+    let(:parent1) { { name: 'parent1',  parent: 3 } }
+    let(:parent2) { { name: 'parent2',  parent: 4 } }
+    let(:parent3) { { name: 'parent3',  parent: 5 } }
+
+    before do
+      allow(ancestry_tree).to receive(:find).with(1).and_return file
+      allow(ancestry_tree).to receive(:find).with(2).and_return parent1
+      allow(ancestry_tree).to receive(:find).with(3).and_return parent2
+      allow(ancestry_tree).to receive(:find).with(4).and_return parent3
+    end
+
+    it { is_expected.to eq %w[parent1 parent2 parent3] }
+  end
+
+  describe '#load_parents' do
+    subject(:tree)    { ancestry_tree.send :tree }
+    let(:nil_entries) { { 1 => nil, 2 => nil, 3 => nil } }
+    let(:records) do
+      [{ id: 2, name: 'file2', parent: 4 },
+       { id: 3, name: 'file3', parent: 5 },
+       { id: 4, name: 'file4', parent: nil }]
+    end
+
+    before do
+      allow(ancestry_tree)
+        .to receive(:nil_entries)
+        .and_return nil_entries, nil_entries, nil_entries.slice(1)
+      allow(ancestry_tree)
+        .to receive(:fetch_records_for).with([1, 2, 3]).and_return records
+      allow(ancestry_tree).to receive(:add_entries)
+      allow(ancestry_tree).to receive(:update_entries)
+      allow(ancestry_tree).to receive(:add_nil_entries)
+    end
+
+    after { ancestry_tree.send :load_parents }
+
+    it 'adds entries for new records' do
+      expect(ancestry_tree).to receive(:add_entries).with(records)
+    end
+
+    it 'updates entries of remaining nil entries (id: 1)' do
+      expect(ancestry_tree).to receive(:update_entries).with([1], false)
+    end
+
+    it 'adds nil entries for parent IDs of new parents (unless nil)' do
+      expect(ancestry_tree).to receive(:add_nil_entries).with([4, 5])
+    end
+
+    context 'when there are no nil entries' do
+      let(:nil_entries) { [] }
+
+      it { expect(ancestry_tree).not_to receive(:fetch_records_for) }
+      it { expect(ancestry_tree).not_to receive(:add_entries) }
+      it { expect(ancestry_tree).not_to receive(:update_entries) }
+      it { expect(ancestry_tree).not_to receive(:add_nil_entries) }
+    end
+  end
+
+  describe '#recursively_load_parents(depth:)' do
+    subject { ancestry_tree.send :recursively_load_parents, depth: 7 }
+    after   { subject }
+    it { expect(ancestry_tree).to receive(:load_parents).exactly(7).times }
+  end
+
+  describe 'add_entries(entries)' do
+    subject(:tree) { ancestry_tree.send :tree }
+    let(:tree_entries) do
+      { 1 => { name: 'f1_old', parent: 'p1_old' },
+        2 => { name: 'f2_old', parent: 'p2_old' } }
+    end
+    let(:new_entries) do
+      [{ id: 2, name: 'f2', parent: 'p2' },
+       { id: 3, name: 'f3', parent: 'p3' },
+       { id: 4, name: 'f4', parent: 'p4' }]
+    end
+
+    before { ancestry_tree.send :tree=, tree_entries }
+    before { ancestry_tree.send :add_entries, new_entries }
+
+    it 'adds new entries' do
+      is_expected.to include(3 => { name: 'f3', parent: 'p3' })
+      is_expected.to include(4 => { name: 'f4', parent: 'p4' })
+    end
+
+    it 'overrides existing entries on conflict' do
+      is_expected.to      include(2 => { name: 'f2', parent: 'p2' })
+      is_expected.not_to  include(2 => { name: 'f2_old', parent: 'p2_old' })
+    end
+
+    it 'it keeps existing entries' do
+      is_expected.to include(1 => { name: 'f1_old', parent: 'p1_old' })
+    end
+  end
+
+  describe '#find(id)' do
+    let(:tree_entries) { { 1 => nil, 2 => false, 3 => 'value' } }
+
+    before { ancestry_tree.send :tree=, tree_entries }
+
+    it 'returns nil for id 1' do
+      expect(ancestry_tree.send(:find, 1)).to eq nil
+    end
+
+    it 'returns nil for id 2 (false-value)' do
+      expect(ancestry_tree.send(:find, 2)).to eq nil
+    end
+
+    it 'returns value for id 3' do
+      expect(ancestry_tree.send(:find, 3)).to eq 'value'
+    end
+  end
+
+  describe 'initialize_tree(file_ids)' do
+    subject(:init_tree) { ancestry_tree.send :initialize_tree, [1, 2, 3] }
+    let(:tree_entries)  { { x: 'y' } }
+
+    before { ancestry_tree.send :tree=, tree_entries }
+    before { allow(ancestry_tree).to receive(:add_nil_entries) }
+
+    it 'resets tree' do
+      init_tree
+      expect(ancestry_tree.send(:tree)).to be_empty
+    end
+
+    it 'adds nil entries for file ids' do
+      expect(ancestry_tree).to receive(:add_nil_entries).with([1, 2, 3])
+      init_tree
+    end
+  end
+
+  describe 'nil_entries' do
+    subject(:nil_entries) { ancestry_tree.send :nil_entries }
+    let(:tree_entries) do
+      { 1 => nil,
+        2 => { name: 'f1_old', parent: 'p1_old' },
+        3 => nil,
+        4 => { name: 'f2_old', parent: 'p2_old' },
+        5 => nil }
+    end
+
+    before { ancestry_tree.send :tree=, tree_entries }
+
+    it 'returns all entries with nil values' do
+      expect(nil_entries.keys).to contain_exactly 1, 3, 5
+    end
+  end
+
+  describe 'add_nil_entries(ids)' do
+    subject(:tree) { ancestry_tree.send :tree }
+    let(:tree_entries) do
+      { 1 => { name: 'f1_old', parent: 'p1_old' },
+        2 => { name: 'f2_old', parent: 'p2_old' } }
+    end
+
+    before { ancestry_tree.send :tree=, tree_entries }
+    before { ancestry_tree.send :add_nil_entries, [2, 3, 4] }
+
+    it 'adds new entries' do
+      is_expected.to include(3 => nil)
+      is_expected.to include(4 => nil)
+    end
+
+    it 'does not override existing entries on conflict' do
+      is_expected.not_to  include(2 => nil)
+      is_expected.to      include(2 => { name: 'f2_old', parent: 'p2_old' })
+    end
+
+    it 'it keeps existing entries' do
+      is_expected.to include(1 => { name: 'f1_old', parent: 'p1_old' })
+    end
+  end
+
+  describe 'update_entries(ids, new_value)' do
+    subject(:tree) { ancestry_tree.send :tree }
+    let(:tree_entries) do
+      { 1 => { name: 'f1_old', parent: 'p1_old' },
+        2 => { name: 'f2_old', parent: 'p2_old' } }
+    end
+
+    before { ancestry_tree.send :tree=, tree_entries }
+    before { ancestry_tree.send :update_entries, [2, 3, 4], 'value' }
+
+    it 'adds new entries' do
+      is_expected.to include(3 => 'value')
+      is_expected.to include(4 => 'value')
+    end
+
+    it 'does override existing entries on conflict' do
+      is_expected.to      include(2 => 'value')
+      is_expected.not_to  include(2 => { name: 'f2_old', parent: 'p2_old' })
+    end
+
+    it 'it keeps existing entries' do
+      is_expected.to include(1 => { name: 'f1_old', parent: 'p1_old' })
+    end
+  end
+end

--- a/spec/models/revision/file_diffs_calculator_spec.rb
+++ b/spec/models/revision/file_diffs_calculator_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+RSpec.describe Revision::FileDiffsCalculator, type: :model do
+  subject(:calculator) { Revision::FileDiffsCalculator.new(revision: revision) }
+  let(:revision)       { instance_double Revision }
+
+  describe '#cache_diffs!' do
+    before { allow(calculator).to receive(:diffs).and_return %w[d1 d2 d3] }
+
+    it 'calls FileDiff.import' do
+      expect(FileDiff).to receive(:import).with(%w[d1 d2 d3], validate: false)
+      calculator.cache_diffs!
+    end
+  end
+
+  describe '#diffs' do
+    it 'calculates diffs' do
+      expect(calculator).to receive(:calculate_diffs)
+      calculator.diffs
+    end
+  end
+
+  describe '#calculate_diffs' do
+    subject(:method) { calculator.send :calculate_diffs }
+
+    let(:raw_diffs) do
+      [{ 'id' => 'raw1' }, { 'id' => 'raw2' }, { 'id' => 'raw3' }]
+    end
+
+    before do
+      allow(calculator).to receive(:raw_diffs).and_return raw_diffs
+      allow(calculator)
+        .to receive(:raw_diff_to_diff)
+        .with('id' => 'raw1')
+        .and_return('id' => 'diff1')
+      allow(calculator)
+        .to receive(:raw_diff_to_diff)
+        .with('id' => 'raw2')
+        .and_return('id' => 'diff2')
+      allow(calculator)
+        .to receive(:raw_diff_to_diff)
+        .with('id' => 'raw3')
+        .and_return('id' => 'diff3')
+    end
+
+    it 'returns raw diffs converted to diffs' do
+      is_expected.to contain_exactly(
+        hash_including('id' => 'diff1'),
+        hash_including('id' => 'diff2'),
+        hash_including('id' => 'diff3')
+      )
+    end
+
+    it 'adds first_three_ancestors' do
+      is_expected.to contain_exactly(
+        hash_including('first_three_ancestors' => []),
+        hash_including('first_three_ancestors' => []),
+        hash_including('first_three_ancestors' => [])
+      )
+    end
+  end
+
+  describe '#raw_diff_to_diff(raw_diff)' do
+    subject(:method) { calculator.send :raw_diff_to_diff, raw_diff }
+
+    let(:raw_diff) do
+      { 'file_resource_id' => 100,
+        'snapshots' => [
+          { 'revision_id' => 1, 'file_resource_snapshot_id' => 9 },
+          { 'revision_id' => 2, 'file_resource_snapshot_id' => 21 }
+        ] }
+    end
+
+    before do
+      allow(revision).to receive(:id).and_return 'revision-id'
+      allow(revision).to receive(:parent_id).and_return 'parent-revision-id'
+      allow(calculator)
+        .to receive(:snapshot_id_from_raw_diff)
+        .with(raw_diff, 'revision-id')
+        .and_return('current-snapshot-id')
+      allow(calculator)
+        .to receive(:snapshot_id_from_raw_diff)
+        .with(raw_diff, 'parent-revision-id')
+        .and_return('previous-snapshot-id')
+    end
+
+    it 'keeps file_resource_id' do
+      is_expected.to include('file_resource_id' => 100)
+    end
+
+    it 'sets revision id' do
+      is_expected.to include('revision_id' => 'revision-id')
+    end
+
+    it 'sets current snapshot id' do
+      is_expected.to include('current_snapshot_id' => 'current-snapshot-id')
+    end
+
+    it 'sets previous snapshot id' do
+      is_expected.to include('previous_snapshot_id' => 'previous-snapshot-id')
+    end
+  end
+
+  describe '#snapshot_id_from_raw_diff(raw_diff, revision_id)' do
+    subject(:method) do
+      calculator.send :snapshot_id_from_raw_diff, raw_diff, revision_id
+    end
+
+    let(:raw_diff) do
+      { 'file_resource_id' => 100,
+        'snapshots' => [
+          { 'revision_id' => 1, 'file_resource_snapshot_id' => 9 },
+          { 'revision_id' => 2, 'file_resource_snapshot_id' => 21 }
+        ] }
+    end
+
+    context 'when revision_id is 1' do
+      let(:revision_id) { 1 }
+      it { is_expected.to eq 9 }
+    end
+
+    context 'when revision_id is 2' do
+      let(:revision_id) { 2 }
+      it { is_expected.to eq 21 }
+    end
+
+    context 'when revision_id does not exist' do
+      let(:revision_id) { 3 }
+      it { is_expected.to eq nil }
+    end
+  end
+end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -26,12 +26,11 @@ RSpec.describe Revision, type: :model do
 
   describe 'validations' do
     it { is_expected.not_to validate_presence_of(:title) }
-    it { is_expected.not_to validate_presence_of(:summary) }
 
     context 'when is_published=true' do
       before  { revision.is_published = true }
       it      { is_expected.to validate_presence_of(:title) }
-      it      { is_expected.to validate_presence_of(:summary) }
+      it      { is_expected.not_to validate_presence_of(:summary) }
     end
   end
 

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe Revision, type: :model do
     before do
       allow(described_class).to receive(:create!).and_return(draft)
       allow(draft).to receive(:commit_all_files_staged_in_project)
+      allow(draft).to receive(:generate_diffs)
       allow(project).to receive(:published_revisions).and_return revisions
     end
 
@@ -91,6 +92,18 @@ RSpec.describe Revision, type: :model do
         .with(%i[revision_id file_resource_id file_resource_snapshot_id],
               query)
       commit_files
+    end
+  end
+
+  describe '#generate_diffs' do
+    subject(:generate_diffs)  { revision.generate_diffs }
+    let(:calculator)          { instance_double Revision::FileDiffsCalculator }
+
+    it 'calls Revision::FileDiffsCalculator#cache_diffs!' do
+      expect(Revision::FileDiffsCalculator)
+        .to receive(:new).with(revision: revision).and_return calculator
+      expect(calculator).to receive(:cache_diffs!)
+      subject
     end
   end
 end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Revision, type: :model do
         .to belong_to(:author).class_name('Profiles::User').dependent(false)
     end
     it { is_expected.to have_many(:committed_files).dependent(:destroy) }
+    it { is_expected.to have_many(:file_diffs).dependent(:destroy) }
   end
 
   describe 'attributes' do


### PR DESCRIPTION
- Add FileDiff model for storing cached file diffs between revisions
- Add Revision::FileDiffCalculator for calculating and persisting diffs to cache
- Add Revision::FileAncestryTree for calculating ancestor names for diffs