### PR TITLE
Travis: Use PSQL 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,6 @@ env:
     - GOOGLE_DRIVE_CLIENT_ID=client_id
     - GOOGLE_DRIVE_CLIENT_SECRET=client_secret
     - GOOGLE_DRIVE_CREDENTIALS_PATH='spec/support/fixtures/google_drive/credentials.yml'
+
+addons:
+  postgresql: '9.6'


### PR DESCRIPTION
Integration spec for Revision::FileDiffCalculator is working locally but failing on Travis. This is probably due to the PostgreSQL being v9.2 and the json_agg() function being unsupported in versions v9.2 and earlier.