### PR TITLE
Fix: Project

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -34,7 +34,8 @@ class Project < ApplicationRecord
     end
   end
 
-  has_many :revisions, dependent: :destroy do
+  has_many :all_revisions, class_name: 'Revision', dependent: :destroy
+  has_many :revisions, -> { where is_published: true } do
     def create_draft_and_commit_files!(author)
       ::Revision.create_draft_and_commit_files_for_project!(
         proxy_association.owner,
@@ -42,9 +43,6 @@ class Project < ApplicationRecord
       )
     end
   end
-  has_many :published_revisions,
-           -> { where is_published: true },
-           class_name: 'Revision'
 
   # Attributes
   # Do not allow owner change

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -11,16 +11,18 @@ class Project < ApplicationRecord
                                           association_foreign_key: 'profile_id',
                                           validate: false
 
+  has_one :staged_root_folder,
+          -> { where is_root: true },
+          class_name: 'StagedFile',
+          dependent: :delete
+  has_one :root_folder, class_name: 'FileResource',
+                        through: :staged_root_folder,
+                        source: :file_resource
+
   has_many :staged_files, dependent: :destroy
   has_many :file_resources_in_stage, class_name: 'FileResource',
                                      through: :staged_files,
                                      source: :file_resource
-  has_one :staged_root_folder,
-          -> { where is_root: true },
-          class_name: 'StagedFile'
-  has_one :root_folder, class_name: 'FileResource',
-                        through: :staged_root_folder,
-                        source: :file_resource
 
   has_many :staged_non_root_files,
            -> { where is_root: false },

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -24,7 +24,7 @@ class Revision < ApplicationRecord
   # in the project
   def self.create_draft_and_commit_files_for_project!(project, author)
     create!(project: project,
-            parent: project.published_revisions.last,
+            parent: project.revisions.last,
             author: author)
       .tap(&:commit_all_files_staged_in_project)
       .tap(&:generate_diffs)

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -59,11 +59,15 @@ RSpec.describe Project, type: :model do
         .source(:file_resource)
         .dependent(false)
     end
-    it { is_expected.to have_many(:revisions).dependent(:destroy) }
     it do
       is_expected
-        .to have_many(:published_revisions)
+        .to have_many(:all_revisions)
         .class_name('Revision')
+        .dependent(:destroy)
+    end
+    it do
+      is_expected
+        .to have_many(:revisions)
         .conditions(is_published: true)
         .dependent(false)
     end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -20,27 +20,27 @@ RSpec.describe Project, type: :model do
         .to have_and_belong_to_many(:collaborators)
         .class_name('Profiles::User').validate(false)
     end
-    it { is_expected.to have_many(:staged_files).dependent(:destroy) }
-    it do
-      is_expected
-        .to have_many(:file_resources_in_stage)
-        .class_name('FileResource')
-        .through(:staged_files)
-        .source(:file_resource)
-        .dependent(false)
-    end
     it do
       is_expected
         .to have_one(:staged_root_folder)
         .conditions(is_root: true)
         .class_name('StagedFile')
-        .dependent(false)
+        .dependent(:delete)
     end
     it do
       is_expected
         .to have_one(:root_folder)
         .class_name('FileResource')
         .through(:staged_root_folder)
+        .source(:file_resource)
+        .dependent(false)
+    end
+    it { is_expected.to have_many(:staged_files).dependent(:destroy) }
+    it do
+      is_expected
+        .to have_many(:file_resources_in_stage)
+        .class_name('FileResource')
+        .through(:staged_files)
         .source(:file_resource)
         .dependent(false)
     end

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Revision, type: :model do
       allow(described_class).to receive(:create!).and_return(draft)
       allow(draft).to receive(:commit_all_files_staged_in_project)
       allow(draft).to receive(:generate_diffs)
-      allow(project).to receive(:published_revisions).and_return revisions
+      allow(project).to receive(:revisions).and_return revisions
     end
 
     after { create_draft }


### PR DESCRIPTION
- Project#revisions refers to published revisions
- On destroy, Project first deletes the staged root folder (because staged
  files are readonly, delete must be used rather than destroy and the staged
  root folder must be deleted prior to destroying the remainder of staged
  files)