### PR TITLE
Fix: FileAncestryTree.generate

### DIFF
--- a/app/models/revision/file_ancestry_tree.rb
+++ b/app/models/revision/file_ancestry_tree.rb
@@ -6,7 +6,9 @@ class Revision
     # Initialize and generate tree
     def self.generate(revision:, file_ids:, depth:)
       tree = new(revision: revision, file_ids: file_ids)
-      tree.recursively_load_parents(depth: depth)
+      # Load generations depth + 1 times because 1st generation is just current
+      # files
+      tree.recursively_load_generations(depth: depth + 1)
       tree
     end
 
@@ -30,8 +32,8 @@ class Revision
       ancestor_names
     end
 
-    # Load parent records for all nil entries
-    def load_parents
+    # Load records for all nil entries
+    def load_generation
       return unless nil_entries.any?
 
       parents = fetch_records_for(nil_entries.keys)
@@ -47,10 +49,10 @@ class Revision
       add_nil_entries(parents.map { |parent| parent[:parent] }.compact)
     end
 
-    # Recursively call #load_parents depth number of times
-    def recursively_load_parents(depth:)
+    # Recursively call #load_generation depth number of times
+    def recursively_load_generations(depth:)
       depth.times do
-        load_parents
+        load_generation
       end
     end
 

--- a/spec/integrations/revision/file_ancestry_tree_spec.rb
+++ b/spec/integrations/revision/file_ancestry_tree_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+RSpec.describe Revision::FileAncestryTree, type: :model do
+  describe '.generate(revision:, file_ids:, depth:)' do
+    subject(:tree) do
+      described_class.generate(revision: revision, file_ids: [f5.id], depth: 3)
+    end
+    let(:revision) { create :revision }
+    let(:f1) { create :file_resource, name: 'f1' }
+    let(:f2) { create :file_resource, name: 'f2', parent: f1 }
+    let(:f3) { create :file_resource, name: 'f3', parent: f2 }
+    let(:f4) { create :file_resource, name: 'f4', parent: f3 }
+    let(:f5) { create :file_resource, name: 'f5', parent: f4 }
+
+    before do
+      # committed files in current revision
+      [f1, f2, f3, f4, f5].each do |file|
+        create :committed_file, revision: revision, file_resource: file
+      end
+    end
+
+    it 'has ancestors names f4, f3, f2' do
+      expect(tree.ancestors_names_for(f5.id, depth: 3))
+        .to eq %w[f4 f3 f2]
+    end
+  end
+end

--- a/spec/models/revision/file_ancestry_tree_spec.rb
+++ b/spec/models/revision/file_ancestry_tree_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Revision::FileAncestryTree, type: :model do
 
   describe '.generate(revision:, file_ids:, depth:)' do
     subject(:generate)  { described_class.generate attributes }
-    let(:attributes)    { { revision: 'r', file_ids: 'ids', depth: 'd' } }
+    let(:attributes)    { { revision: 'r', file_ids: 'ids', depth: 3 } }
     let(:new_tree)      { instance_double described_class }
 
     before do
@@ -17,13 +17,15 @@ RSpec.describe Revision::FileAncestryTree, type: :model do
         .to receive(:new)
         .with(revision: 'r', file_ids: 'ids')
         .and_return new_tree
-      allow(new_tree).to receive(:recursively_load_parents).with(depth: 'd')
+      allow(new_tree)
+        .to receive(:recursively_load_generations).with(depth: 3 + 1)
     end
 
     it { is_expected.to eq new_tree }
 
-    it 'recursively_load_parents depth-times' do
-      expect(new_tree).to receive(:recursively_load_parents).with(depth: 'd')
+    it 'recursively_load_generations depth-times' do
+      expect(new_tree)
+        .to receive(:recursively_load_generations).with(depth: 3 + 1)
       generate
     end
   end
@@ -48,7 +50,7 @@ RSpec.describe Revision::FileAncestryTree, type: :model do
     it { is_expected.to eq %w[parent1 parent2 parent3] }
   end
 
-  describe '#load_parents' do
+  describe '#load_generation' do
     subject(:tree)    { ancestry_tree.send :tree }
     let(:nil_entries) { { 1 => nil, 2 => nil, 3 => nil } }
     let(:records) do
@@ -68,7 +70,7 @@ RSpec.describe Revision::FileAncestryTree, type: :model do
       allow(ancestry_tree).to receive(:add_nil_entries)
     end
 
-    after { ancestry_tree.send :load_parents }
+    after { ancestry_tree.send :load_generation }
 
     it 'adds entries for new records' do
       expect(ancestry_tree).to receive(:add_entries).with(records)
@@ -92,10 +94,10 @@ RSpec.describe Revision::FileAncestryTree, type: :model do
     end
   end
 
-  describe '#recursively_load_parents(depth:)' do
-    subject { ancestry_tree.send :recursively_load_parents, depth: 7 }
+  describe '#recursively_load_generations(depth:)' do
+    subject { ancestry_tree.send :recursively_load_generations, depth: 7 }
     after   { subject }
-    it { expect(ancestry_tree).to receive(:load_parents).exactly(7).times }
+    it { expect(ancestry_tree).to receive(:load_generation).exactly(7).times }
   end
 
   describe 'add_entries(entries)' do


### PR DESCRIPTION
When generating ancestry tree, load generations depth+1 times because
the first generation is just that of the children. So if we want an
ancestry tree with depth 3, we have to load generations 4 times.