### PR TITLE
Add Stage::FileDiff for diffing staged files

### DIFF
--- a/app/models/concerns/diffing.rb
+++ b/app/models/concerns/diffing.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+# Add support for diffing file resources
+module Diffing
+  extend ActiveSupport::Concern
+
+  # Delegations
+  delegate :id, to: :current_or_previous_snapshot, prefix: true
+  delegate :external_id, :external_link, :folder?, :icon, :mime_type, :name,
+           :provider, :provider=, :symbolic_mime_type,
+           to: :current_or_previous_snapshot
+
+  delegate_methods = %i[content_version name parent_id]
+  delegate(*delegate_methods, to: :current_snapshot, prefix: :current)
+  delegate(*delegate_methods, to: :previous_snapshot, prefix: :previous)
+
+  def added?
+    previous_snapshot_id.nil?
+  end
+
+  # Format first_three_ancestors into a path, joined by >
+  # 0 ancestors: Home
+  # 1-2 ancestors: Ancestor2 > Ancestor1
+  # 3(+) ancestors: .. > Ancestor2 > Ancestor1
+  def ancestor_path
+    case first_three_ancestors.length
+    when 0
+      'Home'
+    when 1, 2
+      first_three_ancestors.reverse.join(' > ')
+    when 3
+      first_three_ancestors.reverse.drop(1).unshift('..').join(' > ')
+    end
+  end
+
+  def changed?
+    added? || deleted? || updated?
+  end
+
+  # Return the changes that have been made from previous_snapshot to
+  # current_snapshot. When file has been updated (moved, renamed, or modified),
+  # moved must come first in the list of changes, renamed second, and modified
+  # last.
+  def changes
+    @changes ||=
+      %i[added deleted moved renamed modified].select do |change|
+        send("#{change}?")
+      end
+  end
+
+  def deleted?
+    current_snapshot_id.nil?
+  end
+
+  def modified?
+    return false unless updated?
+    current_content_version != previous_content_version
+  end
+
+  def moved?
+    return false unless updated?
+    current_parent_id != previous_parent_id
+  end
+
+  def renamed?
+    return false unless updated?
+    current_name != previous_name
+  end
+
+  def updated?
+    return false if added? || deleted?
+    current_snapshot_id != previous_snapshot_id
+  end
+
+  def current_or_previous_snapshot
+    current_snapshot || previous_snapshot
+  end
+end

--- a/app/models/file_diff.rb
+++ b/app/models/file_diff.rb
@@ -2,6 +2,8 @@
 
 # Class for handling diffing of File Resources
 class FileDiff < ApplicationRecord
+  include Diffing
+
   # Associations
   belongs_to :revision
   belongs_to :file_resource
@@ -14,17 +16,4 @@ class FileDiff < ApplicationRecord
   # Either current or previous snapshot must be present
   validates :current_snapshot_id, presence: true, unless: :previous_snapshot_id
   validates :previous_snapshot_id, presence: true, unless: :current_snapshot_id
-
-  def added?
-    previous_snapshot_id.nil?
-  end
-
-  def deleted?
-    current_snapshot_id.nil?
-  end
-
-  def updated?
-    # Neither added nor deleted
-    !(added? || deleted?)
-  end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -36,6 +36,11 @@ class Project < ApplicationRecord
     end
   end
 
+  has_many :non_root_file_snapshots_in_stage,
+           class_name: 'FileResource::Snapshot',
+           through: :non_root_file_resources_in_stage,
+           source: :current_snapshot
+
   has_many :all_revisions, class_name: 'Revision', dependent: :destroy
   has_many :revisions, -> { where is_published: true } do
     def create_draft_and_commit_files!(author)

--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -7,6 +7,9 @@ class Revision < ApplicationRecord
   belongs_to :parent, class_name: 'Revision', optional: true, autosave: false
   belongs_to :author, class_name: 'Profiles::User'
   has_many :committed_files, dependent: :destroy
+  has_many :committed_file_snapshots, class_name: 'FileResource::Snapshot',
+                                      through: :committed_files,
+                                      source: :file_resource_snapshot
   has_many :file_diffs, dependent: :destroy
 
   # attributes

--- a/app/models/stage/file_diff.rb
+++ b/app/models/stage/file_diff.rb
@@ -55,9 +55,27 @@ module Stage
       set_file_resource_id_from_snapshots unless file_resource_id.present?
     end
 
+    # Return the ancestors (as snapshots) of this diff
+    def ancestors_in_project
+      return [] if current_or_previous_snapshot.nil?
+
+      Ancestry.for(file_resource_snapshot: current_or_previous_snapshot,
+                   project: project)
+    end
+
     # Return this file's children as an array of Stage::FileDiff instances
     def children_as_diffs
       Children.new(project: project, parent_id: file_resource_id).as_diffs
+    end
+
+    # Return the first three ancestors (names only) of this diff
+    def first_three_ancestors
+      return [] if current_or_previous_snapshot.nil?
+
+      Ancestry
+        .for(file_resource_snapshot: current_or_previous_snapshot,
+             project: project, depth: 3)
+        .map(&:name)
     end
 
     # The ID of the current or previous snapshot

--- a/app/models/stage/file_diff.rb
+++ b/app/models/stage/file_diff.rb
@@ -55,6 +55,16 @@ module Stage
       set_file_resource_id_from_snapshots unless file_resource_id.present?
     end
 
+    # Return this file's children as an array of Stage::FileDiff instances
+    def children_as_diffs
+      Children.new(project: project, parent_id: file_resource_id).as_diffs
+    end
+
+    # The ID of the current or previous snapshot
+    def snapshot_id
+      current_or_previous_snapshot_id
+    end
+
     private
 
     def current_snapshot

--- a/app/models/stage/file_diff.rb
+++ b/app/models/stage/file_diff.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Stage
+  # Class for handling diffing of staged File Resources to those of last
+  # revision
+  class FileDiff
+    attr_accessor :committed_snapshot, :file_resource_id, :project,
+                  :staged_snapshot
+
+    # Initialize a new FileDiff instance for the file resource identified by
+    # external id. Gets staged snapshot from project stage and committed
+    # snapshot from the project's last revision.
+    # Raise ActiveRecord::RecordNotFound if file resource does not exist at all
+    # Raise ActiveRecord::RecordNotFound if file is found neither in stage nor
+    # in last revision.
+    def self.find_by!(external_id:, project:)
+      file = FileResource.find_by!(external_id: external_id)
+
+      staged = staged_snapshot_for(file, project)
+      committed = last_committed_snapshot_for(file, project)
+
+      # Raise error if both staged and committed are nil
+      raise ActiveRecord::RecordNotFound if staged.nil? && committed.nil?
+
+      new(project: project,
+          staged_snapshot: staged, committed_snapshot: committed)
+    end
+
+    # Get the current snapshot for the given file resource staged in project
+    def self.staged_snapshot_for(file_resource, project)
+      project
+        .non_root_file_snapshots_in_stage
+        .find_by(file_resource: file_resource)
+    end
+
+    # Get the committed snapshot for the given file resource from the project's
+    # last revision
+    def self.last_committed_snapshot_for(file_resource, project)
+      project
+        .revisions
+        &.last
+        &.committed_file_snapshots
+        &.find_by(file_resource: file_resource)
+    end
+
+    def initialize(attributes = {})
+      self.project            = attributes.delete(:project)
+      self.staged_snapshot    = attributes.delete(:staged_snapshot)
+      self.committed_snapshot = attributes.delete(:committed_snapshot)
+      self.file_resource_id   = attributes.delete(:file_resource_id)
+
+      # Set file resource id if not yet set
+      set_file_resource_id_from_snapshots unless file_resource_id.present?
+    end
+
+    private
+
+    def set_file_resource_id_from_snapshots
+      self.file_resource_id =
+        (staged_snapshot || committed_snapshot)&.file_resource_id
+    end
+  end
+end

--- a/app/models/stage/file_diff.rb
+++ b/app/models/stage/file_diff.rb
@@ -4,6 +4,8 @@ module Stage
   # Class for handling diffing of staged File Resources to those of last
   # revision
   class FileDiff
+    include Diffing
+
     attr_accessor :committed_snapshot, :file_resource_id, :project,
                   :staged_snapshot
 
@@ -54,6 +56,22 @@ module Stage
     end
 
     private
+
+    def current_snapshot
+      staged_snapshot
+    end
+
+    def current_snapshot_id
+      staged_snapshot&.id
+    end
+
+    def previous_snapshot
+      committed_snapshot
+    end
+
+    def previous_snapshot_id
+      committed_snapshot&.id
+    end
 
     def set_file_resource_id_from_snapshots
       self.file_resource_id =

--- a/app/models/stage/file_diff/ancestry.rb
+++ b/app/models/stage/file_diff/ancestry.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Stage
+  class FileDiff
+    # Class for retrieving ancestry of a Stage::FileDiff
+    class Ancestry
+      # Retrieve ancestry for the file resource identified by given ID
+      # Return an array of FileResource::Snapshot instances
+      # Can return ancestors up to depth x by passing the depth parameter.
+      # TODO: Convert this into a single recursive ActiveRecord query
+      def self.for(file_resource_snapshot:, project:, depth: -1)
+        return [] if depth.zero?
+
+        parent = parent_snapshot_in_stage(file_resource_snapshot, project)
+        parent ||=
+          parent_snapshot_in_last_revision(file_resource_snapshot, project)
+
+        return [] if parent.nil?
+
+        # call Ancestry again
+        [parent] + self.for(file_resource_snapshot: parent,
+                            project: project, depth: depth - 1)
+      end
+
+      def self.parent_snapshot_in_stage(snapshot, project)
+        project
+          .non_root_file_snapshots_in_stage
+          .find_by(file_resource_id: snapshot.parent_id)
+      end
+
+      def self.parent_snapshot_in_last_revision(snapshot, project)
+        project
+          .revisions
+          .last
+          &.committed_file_snapshots
+          &.find_by(file_resource_id: snapshot.parent_id)
+      end
+    end
+  end
+end

--- a/app/models/stage/file_diff/children.rb
+++ b/app/models/stage/file_diff/children.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module Stage
+  class FileDiff
+    # Class for calculating children (as diffs) of a staged file diff
+    # TODO: Needs unit spec
+    class Children
+      def initialize(project:, parent_id:)
+        self.project    = project
+        self.parent_id  = parent_id
+      end
+
+      # Return the file's children as Stage::FileDiff instances
+      def as_diffs
+        children = children_of_staged_and_committed_file
+
+        # Convert snapshots into Stage::FileDiff instances
+        children =
+          children.group_by(&:file_resource_id).values.map do |group|
+            children_snapshots_to_diff(group)
+          end
+
+        # For each child removed from this parent folder, check if it was moved
+        # to another folder (as opposed to having been deleted)
+        remove_children_moved_to_another_folder!(children)
+
+        # For each child added to this parent folder, check it it was moved from
+        # another folder (as opposed to having been added)
+        update_children_moved_into_this_folder!(children)
+
+        children
+      end
+
+      private
+
+      attr_accessor :project, :parent_id
+
+      # Return true if the given child_id among the children IDs of the
+      # committed file
+      def child_of_committed_file?(child_id)
+        children_ids_of_committed_file.include?(child_id)
+      end
+
+      # Return true if the given child_id among the children IDs of the staged
+      # file
+      def child_of_staged_file?(child_id)
+        children_ids_of_staged_file.include?(child_id)
+      end
+
+      # Return the children IDs of the committed file
+      def children_ids_of_committed_file
+        @children_ids_of_committed_file ||=
+          project
+          .revisions&.last
+          &.committed_file_snapshots&.where(parent_id: parent_id)&.pluck(:id)
+          .to_a
+      end
+
+      # Return the children IDs of the staged file
+      def children_ids_of_staged_file
+        @children_ids_of_staged_file ||=
+          project
+          .non_root_file_snapshots_in_stage
+          .where(parent_id: parent_id)
+          .pluck(:id)
+      end
+
+      # Return the children of both the staged and committed file
+      def children_of_staged_and_committed_file
+        children_of_staged_and_committed_file =
+          children_ids_of_staged_file + children_ids_of_committed_file
+        # TODO: Needs to be sorted correctly, folder 1st, then by current or
+        #       previous name. The current query won't work for that because
+        #       we don't know if the snapshot is staged or committed
+        FileResource::Snapshot
+          .where(id: children_of_staged_and_committed_file.uniq)
+      end
+
+      # Return an instance of Stage::FileDiff for the given array of children
+      def children_snapshots_to_diff(children)
+        staged_snapshot =
+          children.find { |child| child_of_staged_file?(child.id) }
+        committed_snapshot =
+          children.find { |child| child_of_committed_file?(child.id) }
+
+        Stage::FileDiff.new(project: project,
+                            staged_snapshot: staged_snapshot,
+                            committed_snapshot: committed_snapshot)
+      end
+
+      # Alter the given array of children by removing files that exist
+      # elsewhere in the project's stage
+      def remove_children_moved_to_another_folder!(children)
+        deleted_children = children.select(&:deleted?)
+
+        ids_of_deleted_children_in_stage =
+          project
+          .non_root_file_snapshots_in_stage
+          .where(file_resource: deleted_children.map(&:file_resource_id))
+          .pluck(:file_resource_id)
+
+        children.reject! do |child|
+          ids_of_deleted_children_in_stage.include?(child.file_resource_id)
+        end
+      end
+
+      # Alter the given array of children by adding committed snapshots for
+      # files that exist elsewhere in the project's last revision
+      def update_children_moved_into_this_folder!(children)
+        added_children = children.select(&:added?)
+
+        snapshots_of_added_children_in_last_revision =
+          project.revisions&.last&.committed_file_snapshots
+                 &.where(file_resource: added_children.map(&:file_resource_id))
+                 .to_a
+
+        added_children.each do |child|
+          child.committed_snapshot =
+            snapshots_of_added_children_in_last_revision
+            .find { |c| c.file_resource_id == child.file_resource_id }
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/stage/file_diffs.rb
+++ b/spec/factories/stage/file_diffs.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryGirl.define do
+  factory :staged_file_diff, class: Stage::FileDiff do
+    project
+    association :staged_snapshot, factory: :file_resource_snapshot
+    association :committed_snapshot, factory: :file_resource_snapshot
+  end
+end

--- a/spec/integrations/stage/file_diff/ancestry_spec.rb
+++ b/spec/integrations/stage/file_diff/ancestry_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Stage::FileDiff::Ancestry, type: :model do
+  describe '.for(file_resource_snapshot:, project:)' do
+    subject(:ancestors) do
+      described_class.for(file_resource_snapshot: snapshot, project: project)
+    end
+
+    let(:project)   { create :project }
+    let(:root)      { create :file_resource, name: 'r6' }
+    let(:parent5)   { create :file_resource, name: 'p5', parent: root }
+    let(:parent4)   { create :file_resource, name: 'p4', parent: parent5 }
+    let(:parent3)   { create :file_resource, name: 'p3', parent: parent4 }
+    let(:parent2)   { create :file_resource, name: 'p2', parent: parent3 }
+    let(:parent1)   { create :file_resource, name: 'p1', parent: parent2 }
+    let(:child)     { create :file_resource, name: 'c0', parent: parent1 }
+    let(:snapshot) do
+      Stage::FileDiff
+        .find_by!(external_id: child.external_id, project: project)
+        .current_or_previous_snapshot
+    end
+
+    let(:create_revision) do
+      r = create(:revision, project: project)
+      r.commit_all_files_staged_in_project
+      r.update(is_published: revision_is_published, title: 'origin revision')
+    end
+    let(:revision_is_published) { true }
+
+    before do
+      # add all to stage
+      project.root_folder = root
+      child # init all files
+
+      # create revision
+      create_revision
+
+      # update ancestors
+      parent2.update(name: 'updated-p2', parent: parent4)
+    end
+
+    it 'has the right ancestors' do
+      expect(ancestors.map(&:name)).to eq %w[p1 updated-p2 p4 p5]
+      expect(ancestors.map(&:file_resource_id))
+        .to eq [parent1, parent2, parent4, parent5].map(&:id)
+    end
+
+    context 'when some ancestors are deleted in stage' do
+      before do
+        [child, parent1, parent2].each do |file|
+          file.update(is_deleted: true)
+        end
+      end
+
+      it 'uses ancestors from last revision' do
+        expect(ancestors.map(&:name)).to eq %w[p1 p2 p3 p4 p5]
+        expect(ancestors.map(&:file_resource_id))
+          .to eq [parent1, parent2, parent3, parent4, parent5].map(&:id)
+      end
+    end
+
+    context 'when there is no published revision' do
+      let(:revision_is_published) { false }
+
+      it 'has the right ancestors' do
+        expect(ancestors.map(&:name)).to eq %w[p1 updated-p2 p4 p5]
+        expect(ancestors.map(&:file_resource_id))
+          .to eq [parent1, parent2, parent4, parent5].map(&:id)
+      end
+    end
+  end
+end

--- a/spec/integrations/stage/file_diff/children_spec.rb
+++ b/spec/integrations/stage/file_diff/children_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Stage::FileDiff::Children, type: :model do
+  describe '#as_diffs' do
+    subject(:diffs) { children.as_diffs }
+    let(:children) do
+      Stage::FileDiff::Children.new(project: project, parent_id: folder.id)
+    end
+
+    let(:project) { create :project }
+    let(:root)    { create :file_resource }
+    let(:folder) { create :file_resource, parent: root }
+    let(:to_ignore) { create_list :file_resource, 2, parent: root }
+    let(:no_change) { create_list :file_resource, 2, parent: folder }
+    let(:to_add) { create_list :file_resource, 2, parent: folder }
+    let(:to_delete) { create_list :file_resource, 2, parent: folder }
+    let(:to_move_out) { create_list :file_resource, 2, parent: folder }
+    let(:to_move_in) { create_list :file_resource, 2, parent: root }
+    let(:to_rename) { create_list :file_resource, 2, parent: folder }
+    let(:to_modify) { create_list :file_resource, 2, parent: folder }
+    let(:init_all) do
+      [folder, no_change, to_delete, to_move_out, to_move_in, to_rename,
+       to_modify, to_ignore]
+    end
+    let(:create_revision) do
+      r = create(:revision, project: project)
+      r.commit_all_files_staged_in_project
+      r.update(is_published: true, title: 'origin revision')
+    end
+
+    before do
+      # add all to stage
+      project.root_folder = root
+      init_all
+
+      # create revision
+      create_revision
+
+      # make changes
+      to_add
+      to_delete.each { |f| f.update(is_deleted: true) }
+      to_move_out.each { |f| f.update(parent_id: folder.parent_id) }
+      to_move_in.each { |f| f.update(parent_id: folder.id) }
+      to_rename.each { |f| f.update(name: 'new-name') }
+      to_modify.each { |f| f.update(content_version: 'new') }
+    end
+
+    it 'has the right children' do
+      expect(diffs.length).to eq 12
+
+      expect(diffs.reject(&:changed?).map(&:file_resource_id))
+        .to contain_exactly(*no_change.map(&:id))
+
+      expect(diffs.select(&:added?).map(&:file_resource_id))
+        .to contain_exactly(*to_add.map(&:id))
+
+      expect(diffs.select(&:deleted?).map(&:file_resource_id))
+        .to contain_exactly(*to_delete.map(&:id))
+
+      expect(diffs.select(&:moved?).map(&:file_resource_id))
+        .to contain_exactly(*to_move_in.map(&:id))
+
+      expect(diffs.select(&:renamed?).map(&:file_resource_id))
+        .to contain_exactly(*to_rename.map(&:id))
+
+      expect(diffs.select(&:modified?).map(&:file_resource_id))
+        .to contain_exactly(*to_modify.map(&:id))
+    end
+
+    it 'does not have children that belong to other folders' do
+      expect(diffs.map(&:file_resource_id))
+        .not_to include(*to_move_out.map(&:id))
+      expect(diffs.map(&:file_resource_id))
+        .not_to include(*to_ignore.map(&:id))
+    end
+
+    context 'when there is no published revision' do
+      let(:create_revision) do
+        r = create(:revision, project: project)
+        r.commit_all_files_staged_in_project
+      end
+      let(:child_files) do
+        no_change + to_add + to_move_in + to_rename + to_modify
+      end
+
+      it 'has all diffs as added' do
+        expect(diffs).to be_all(&:added?)
+        expect(diffs.map(&:file_resource_id))
+          .to contain_exactly(*child_files.map(&:id))
+      end
+    end
+  end
+end

--- a/spec/integrations/stage/file_diff_spec.rb
+++ b/spec/integrations/stage/file_diff_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Stage::FileDiff, type: :model do
+  describe '#find_by!(external_id:, project:)' do
+    subject(:find) do
+      Stage::FileDiff.find_by!(external_id: external_id, project: project)
+    end
+    let(:external_id)   { file_resource.external_id }
+    let(:project)       { create :project }
+    let(:revision)      { create :revision, project: project }
+    let(:file_resource) { create :file_resource }
+    let(:add_to_stage)  { project.file_resources_in_stage << file_resource }
+    let(:add_to_last_revision) do
+      revision.committed_files.create!(
+        file_resource: file_resource, file_resource_snapshot: committed_snapshot
+      )
+    end
+    let(:committed_snapshot) do
+      file_resource.update!(name: 'new-name')
+      file_resource.snapshots.first
+    end
+    let(:publish_revision) { revision.update!(is_published: true, title: 't') }
+
+    before { add_to_stage }
+    before { add_to_last_revision }
+    before { publish_revision }
+
+    context 'when file is in both stage and last revision' do
+      it 'sets staged_snapshot' do
+        expect(find.staged_snapshot.id).to eq file_resource.current_snapshot_id
+      end
+
+      it 'sets committed_snapshot' do
+        expect(find.committed_snapshot.id).to eq committed_snapshot.id
+      end
+    end
+
+    context 'when file exists only in stage' do
+      let(:add_to_last_revision) { nil }
+
+      it 'sets staged_snapshot' do
+        expect(find.staged_snapshot.id).to eq file_resource.current_snapshot_id
+      end
+
+      it { expect(find.committed_snapshot).to be_nil }
+    end
+
+    context 'when file exists only in last revision' do
+      let(:add_to_stage) { nil }
+
+      it { expect(find.staged_snapshot).to be_nil }
+
+      it 'sets committed_snapshot' do
+        expect(find.committed_snapshot.id).to eq committed_snapshot.id
+      end
+    end
+
+    context 'when file is in neither stage nor last revision' do
+      let(:add_to_stage) { nil }
+      let(:add_to_last_revision) { nil }
+
+      it { expect { find }.to raise_error ActiveRecord::RecordNotFound }
+    end
+
+    context 'when file resource does not exist' do
+      let(:external_id) { 'non-existing-id' }
+
+      it { expect { find }.to raise_error ActiveRecord::RecordNotFound }
+    end
+
+    context 'when project does not have a published last revision' do
+      let(:publish_revision) { nil }
+
+      it 'sets staged_snapshot' do
+        expect(find.staged_snapshot.id).to eq file_resource.current_snapshot_id
+      end
+
+      it { expect(find.committed_snapshot).to be_nil }
+    end
+
+    context 'when project does not have a last revision' do
+      let(:revision)              { nil }
+      let(:add_to_last_revision)  { nil }
+      let(:publish_revision)      { nil }
+
+      it 'sets staged_snapshot' do
+        expect(find.staged_snapshot.id).to eq file_resource.current_snapshot_id
+      end
+
+      it { expect(find.committed_snapshot).to be_nil }
+    end
+  end
+end

--- a/spec/models/file_diff_spec.rb
+++ b/spec/models/file_diff_spec.rb
@@ -1,7 +1,19 @@
 # frozen_string_literal: true
 
+require 'models/shared_examples/being_diffing.rb'
+
 RSpec.describe FileDiff, type: :model do
   subject(:diff) { build_stubbed :file_diff }
+
+  it_should_behave_like 'being diffing' do
+    let(:diffing) do
+      build_stubbed :file_diff,
+                    current_snapshot: current_snapshot,
+                    previous_snapshot: previous_snapshot
+    end
+    let(:current_snapshot)  { build_stubbed :file_resource_snapshot }
+    let(:previous_snapshot) { build_stubbed :file_resource_snapshot }
+  end
 
   describe 'associations' do
     it { is_expected.to belong_to(:revision).autosave(false).dependent(false) }
@@ -31,58 +43,6 @@ RSpec.describe FileDiff, type: :model do
     context 'when current_snapshot_id is nil' do
       before  { diff.current_snapshot_id = nil }
       it      { is_expected.to validate_presence_of(:previous_snapshot_id) }
-    end
-  end
-
-  describe '#added?' do
-    before { diff.current_snapshot_id = 123 }
-    before { diff.previous_snapshot_id = previous_snapshot_id }
-
-    context 'when previous_snapshot_id is nil' do
-      let(:previous_snapshot_id) { nil }
-      it { is_expected.to be_added }
-    end
-
-    context 'when previous_snapshot_id is not nil' do
-      let(:previous_snapshot_id) { 456 }
-      it { is_expected.not_to be_added }
-    end
-  end
-
-  describe '#updated?' do
-    let(:is_added) { false }
-    let(:is_deleted) { false }
-
-    before do
-      allow(diff).to receive(:added?).and_return is_added
-      allow(diff).to receive(:deleted?).and_return is_deleted
-    end
-
-    it { is_expected.to be_updated }
-
-    context 'when diff is added' do
-      let(:is_added) { true }
-      it { is_expected.not_to be_updated }
-    end
-
-    context 'when diff is deleted' do
-      let(:is_deleted) { true }
-      it { is_expected.not_to be_updated }
-    end
-  end
-
-  describe '#deleted?' do
-    before { diff.previous_snapshot_id = 123 }
-    before { diff.current_snapshot_id = current_snapshot_id }
-
-    context 'when current_snapshot_id is nil' do
-      let(:current_snapshot_id) { nil }
-      it { is_expected.to be_deleted }
-    end
-
-    context 'when current_snapshot_id is not nil' do
-      let(:current_snapshot_id) { 456 }
-      it { is_expected.not_to be_deleted }
     end
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe Project, type: :model do
     end
     it do
       is_expected
+        .to have_many(:non_root_file_snapshots_in_stage)
+        .class_name('FileResource::Snapshot')
+        .through(:non_root_file_resources_in_stage)
+        .source(:current_snapshot)
+        .dependent(false)
+    end
+    it do
+      is_expected
         .to have_many(:all_revisions)
         .class_name('Revision')
         .dependent(:destroy)

--- a/spec/models/shared_examples/being_diffing.rb
+++ b/spec/models/shared_examples/being_diffing.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'being diffing' do
+  subject { diffing }
+
+  describe 'delegations' do
+    let(:snapshot) { :current_or_previous_snapshot }
+
+    it { is_expected.to delegate_method(:id).to(snapshot).with_prefix }
+    it { is_expected.to delegate_method(:external_id).to(snapshot) }
+    it { is_expected.to delegate_method(:external_link).to(snapshot) }
+    it { is_expected.to delegate_method(:folder?).to(snapshot) }
+    it { is_expected.to delegate_method(:icon).to(snapshot) }
+    it { is_expected.to delegate_method(:mime_type).to(snapshot) }
+    it { is_expected.to delegate_method(:name).to(snapshot) }
+    it { is_expected.to delegate_method(:provider).to(snapshot) }
+    it { is_expected.to respond_to(:provider=) }
+    it { is_expected.to delegate_method(:symbolic_mime_type).to(snapshot) }
+
+    it do
+      is_expected
+        .to delegate_method(:content_version)
+        .to(:current_snapshot).with_prefix(:current)
+    end
+    it do
+      is_expected
+        .to delegate_method(:name)
+        .to(:current_snapshot).with_prefix(:current)
+    end
+    it do
+      is_expected
+        .to delegate_method(:parent_id)
+        .to(:current_snapshot).with_prefix(:current)
+    end
+
+    it do
+      is_expected
+        .to delegate_method(:content_version)
+        .to(:previous_snapshot).with_prefix(:previous)
+    end
+    it do
+      is_expected
+        .to delegate_method(:name)
+        .to(:previous_snapshot).with_prefix(:previous)
+    end
+    it do
+      is_expected
+        .to delegate_method(:parent_id)
+        .to(:previous_snapshot).with_prefix(:previous)
+    end
+  end
+
+  describe '#added?' do
+    before do
+      allow(diffing).to receive(:current_snapshot_id).and_return 123
+      allow(diffing)
+        .to receive(:previous_snapshot_id).and_return previous_snapshot_id
+    end
+
+    context 'when previous_snapshot_id is nil' do
+      let(:previous_snapshot_id) { nil }
+      it { is_expected.to be_added }
+    end
+
+    context 'when previous_snapshot_id is not nil' do
+      let(:previous_snapshot_id) { 456 }
+      it { is_expected.not_to be_added }
+    end
+  end
+
+  describe '#ancestor_path' do
+    subject { diffing.ancestor_path }
+    before  do
+      allow(diffing).to receive(:first_three_ancestors).and_return ancestors
+    end
+
+    context 'when first_three_ancestors = []' do
+      let(:ancestors) { [] }
+      it { is_expected.to eq 'Home' }
+    end
+
+    context 'when first_three_ancestors = [anc1]' do
+      let(:ancestors) { %w[anc1] }
+      it { is_expected.to eq 'anc1' }
+    end
+
+    context 'when first_three_ancestors = [anc1 anc2]' do
+      let(:ancestors) { %w[anc1 anc2] }
+      it { is_expected.to eq 'anc2 > anc1' }
+    end
+
+    context 'when first_three_ancestors = [anc1 anc2 anc3]' do
+      let(:ancestors) { %w[anc1 anc2 anc3] }
+      it { is_expected.to eq '.. > anc2 > anc1' }
+    end
+  end
+
+  describe '#changed?' do
+    let(:is_added)    { false }
+    let(:is_deleted)  { false }
+    let(:is_updated)  { false }
+
+    before do
+      allow(diffing).to receive(:added?).and_return is_added
+      allow(diffing).to receive(:deleted?).and_return is_deleted
+      allow(diffing).to receive(:updated?).and_return is_updated
+    end
+
+    it { is_expected.not_to be_changed }
+
+    context 'when it is added' do
+      let(:is_added)  { true }
+      it              { is_expected.to be_changed }
+    end
+
+    context 'when it is deleted' do
+      let(:is_deleted)  { true }
+      it                { is_expected.to be_changed }
+    end
+
+    context 'when it is updated' do
+      let(:is_updated)  { true }
+      it                { is_expected.to be_changed }
+    end
+  end
+
+  describe '#changes' do
+    subject { diffing.changes }
+    let(:is_added)    { false }
+    let(:is_deleted)  { false }
+    let(:is_modified) { false }
+    let(:is_moved)    { false }
+    let(:is_renamed)  { false }
+
+    before do
+      allow(diffing).to receive(:added?).and_return is_added
+      allow(diffing).to receive(:deleted?).and_return is_deleted
+      allow(diffing).to receive(:modified?).and_return is_modified
+      allow(diffing).to receive(:moved?).and_return is_moved
+      allow(diffing).to receive(:renamed?).and_return is_renamed
+    end
+
+    it { is_expected.to eq [] }
+
+    context 'when it is added, renamed, and deleted' do
+      let(:is_added)    { true }
+      let(:is_renamed)  { true }
+      let(:is_deleted)  { true }
+      it { is_expected.to contain_exactly :added, :renamed, :deleted }
+    end
+
+    context 'when file is moved, renamed, and modified' do
+      let(:is_moved)    { true }
+      let(:is_renamed)  { true }
+      let(:is_modified) { true }
+
+      it 'the first change is moved' do
+        expect(subject.first).to eq :moved
+      end
+    end
+
+    context 'when file is renamed and modified' do
+      let(:is_renamed)  { true }
+      let(:is_modified) { true }
+
+      it 'the first change is renamed' do
+        expect(subject.first).to eq :renamed
+      end
+    end
+  end
+
+  describe '#deleted?' do
+    before do
+      allow(diffing).to receive(:previous_snapshot_id).and_return 123
+      allow(diffing)
+        .to receive(:current_snapshot_id).and_return current_snapshot_id
+    end
+
+    context 'when current_snapshot_id is nil' do
+      let(:current_snapshot_id) { nil }
+      it { is_expected.to be_deleted }
+    end
+
+    context 'when current_snapshot_id is not nil' do
+      let(:current_snapshot_id) { 456 }
+      it { is_expected.not_to be_deleted }
+    end
+  end
+
+  describe 'modified?' do
+    let(:current_version)   { '123' }
+    let(:previous_version)  { 'abc' }
+    let(:is_updated)        { true }
+
+    before do
+      allow(diffing).to receive(:updated?).and_return is_updated
+      allow(diffing)
+        .to receive(:current_content_version).and_return current_version
+      allow(diffing)
+        .to receive(:previous_content_version).and_return previous_version
+    end
+
+    it { expect(diffing).to be_modified }
+
+    context 'when content versions are the same' do
+      let(:current_version)  { 'same' }
+      let(:previous_version) { 'same' }
+
+      it { expect(diffing).not_to be_modified }
+    end
+
+    context 'when it is not updated' do
+      let(:is_updated) { false }
+      it { expect(diffing).not_to be_modified }
+    end
+  end
+
+  describe 'moved?' do
+    let(:current_parent_id)   { 51 }
+    let(:previous_parent_id)  { 99 }
+    let(:is_updated)          { true }
+
+    before do
+      allow(diffing).to receive(:updated?).and_return is_updated
+      allow(diffing).to receive(:current_parent_id).and_return current_parent_id
+      allow(diffing)
+        .to receive(:previous_parent_id).and_return previous_parent_id
+    end
+
+    it { expect(diffing).to be_moved }
+
+    context 'when parents are the same' do
+      let(:current_parent_id)   { 100 }
+      let(:previous_parent_id)  { 100 }
+
+      it { expect(diffing).not_to be_moved }
+    end
+
+    context 'when it is not updated' do
+      let(:is_updated) { false }
+      it { expect(diffing).not_to be_moved }
+    end
+  end
+
+  describe 'renamed?' do
+    let(:current_name)  { 'File A' }
+    let(:previous_name) { 'File B' }
+    let(:is_updated)    { true }
+
+    before do
+      allow(diffing).to receive(:updated?).and_return is_updated
+      allow(diffing).to receive(:current_name).and_return current_name
+      allow(diffing).to receive(:previous_name).and_return previous_name
+    end
+
+    it { expect(diffing).to be_renamed }
+
+    context 'when names are the same' do
+      let(:current_name)   { 'name' }
+      let(:previous_name)  { 'name' }
+
+      it { expect(diffing).not_to be_renamed }
+    end
+
+    context 'when it is not updated' do
+      let(:is_updated) { false }
+      it { expect(diffing).not_to be_renamed }
+    end
+  end
+
+  describe '#updated?' do
+    let(:is_added)              { false }
+    let(:is_deleted)            { false }
+    let(:current_snapshot_id)   { 1 }
+    let(:previous_snapshot_id)  { 2 }
+
+    before do
+      allow(diffing).to receive(:added?).and_return is_added
+      allow(diffing).to receive(:deleted?).and_return is_deleted
+      allow(diffing)
+        .to receive(:current_snapshot_id).and_return current_snapshot_id
+      allow(diffing)
+        .to receive(:previous_snapshot_id).and_return previous_snapshot_id
+    end
+
+    it { is_expected.to be_updated }
+
+    context 'when snapshot IDs are the same' do
+      let(:current_snapshot_id)   { 13 }
+      let(:previous_snapshot_id)  { 13 }
+      it { is_expected.not_to be_updated }
+    end
+
+    context 'when diffing is added' do
+      let(:is_added) { true }
+      it { is_expected.not_to be_updated }
+    end
+
+    context 'when diffing is deleted' do
+      let(:is_deleted) { true }
+      it { is_expected.not_to be_updated }
+    end
+  end
+end

--- a/spec/models/stage/file_diff/ancestry_spec.rb
+++ b/spec/models/stage/file_diff/ancestry_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe Stage::FileDiff::Ancestry, type: :model do
+  subject(:ancestry) { described_class }
+
+  describe '.for(file_resource_snapshot:, project:, depth: nil)' do
+    subject do
+      ancestry.for(file_resource_snapshot: 'snapshot', project: 'p')
+    end
+    let(:parent_in_stage)     { 'parent-in-stage' }
+    let(:parent_in_revision)  { 'parent-in-revision' }
+
+    before do
+      allow(ancestry).to receive(:for).and_call_original
+      allow(ancestry)
+        .to receive(:parent_snapshot_in_stage)
+        .with('snapshot', 'p')
+        .and_return parent_in_stage
+      allow(ancestry)
+        .to receive(:parent_snapshot_in_last_revision)
+        .with('snapshot', 'p')
+        .and_return parent_in_revision
+      allow(ancestry)
+        .to receive(:for)
+        .with(file_resource_snapshot: parent_in_stage, project: 'p', depth: -2)
+        .and_return ['output_from_recursive_call1']
+      allow(ancestry)
+        .to receive(:for)
+        .with(file_resource_snapshot: parent_in_revision, project: 'p',
+              depth: -2)
+        .and_return ['output_from_recursive_call2']
+    end
+
+    it { is_expected.to eq %w[parent-in-stage output_from_recursive_call1] }
+
+    context 'when parent is not in stage' do
+      let(:parent_in_stage) { nil }
+
+      it do
+        is_expected.to eq %w[parent-in-revision output_from_recursive_call2]
+      end
+    end
+
+    context 'when parent is in neither stage nor revision' do
+      let(:parent_in_stage) { nil }
+      let(:parent_in_revision) { nil }
+
+      it { is_expected.to eq [] }
+    end
+
+    context 'when depth is 0' do
+      subject do
+        ancestry.for(file_resource_snapshot: 's', project: 'p', depth: 0)
+      end
+
+      it { is_expected.to eq [] }
+    end
+  end
+end

--- a/spec/models/stage/file_diff/children_spec.rb
+++ b/spec/models/stage/file_diff/children_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe Stage::FileDiff::Children, type: :model do
+  subject(:diff_children) do
+    Stage::FileDiff::Children.new(project: project, parent_id: parent_id)
+  end
+  let(:project)   { nil }
+  let(:parent_id) { nil }
+
+  describe '#as_diffs' do
+    subject         { diff_children.as_diffs }
+    let(:children)  { [c1, c2, c3, c4] }
+    let(:c1)        { instance_double FileResource::Snapshot }
+    let(:c2)        { instance_double FileResource::Snapshot }
+    let(:c3)        { instance_double FileResource::Snapshot }
+    let(:c4)        { instance_double FileResource::Snapshot }
+
+    before do
+      allow(diff_children)
+        .to receive(:children_of_staged_and_committed_file).and_return children
+      allow(c1).to receive(:file_resource_id).and_return 1
+      allow(c2).to receive(:file_resource_id).and_return 2
+      allow(c3).to receive(:file_resource_id).and_return 3
+      allow(c4).to receive(:file_resource_id).and_return 1
+
+      allow(diff_children)
+        .to receive(:children_snapshots_to_diff).with([c1, c4]).and_return 'd1'
+      allow(diff_children)
+        .to receive(:children_snapshots_to_diff).with([c2]).and_return 'd2'
+      allow(diff_children)
+        .to receive(:children_snapshots_to_diff).with([c3]).and_return 'd3'
+      allow(diff_children).to receive(:remove_children_moved_to_another_folder!)
+      allow(diff_children).to receive(:update_children_moved_into_this_folder!)
+    end
+
+    it { is_expected.to eq %w[d1 d2 d3] }
+
+    it 'calls #remove_children_moved_to_another_folder!' do
+      expect(diff_children)
+        .to receive(:remove_children_moved_to_another_folder!)
+        .with(%w[d1 d2 d3])
+      subject
+    end
+
+    it 'calls #update_children_moved_into_this_folder!' do
+      expect(diff_children)
+        .to receive(:update_children_moved_into_this_folder!)
+        .with(%w[d1 d2 d3])
+      subject
+    end
+  end
+
+  describe '#remove_children_moved_to_another_folder!(children)' do
+    subject do
+      diff_children.send :remove_children_moved_to_another_folder!, children
+    end
+    let(:children)  { [c1, c2, c3] }
+    let(:c1)        { instance_double Stage::FileDiff }
+    let(:c2)        { instance_double Stage::FileDiff }
+    let(:c3)        { instance_double Stage::FileDiff }
+    let(:project)   { instance_double Project }
+
+    before do
+      allow(c1).to receive(:deleted?).and_return false
+      allow(c1).to receive(:file_resource_id).and_return 1
+      allow(c2).to receive(:deleted?).and_return true
+      allow(c2).to receive(:file_resource_id).and_return 2
+      allow(c3).to receive(:deleted?).and_return true
+      allow(c3).to receive(:file_resource_id).and_return 3
+
+      snapshot_class = class_double FileResource::Snapshot
+      query = class_double FileResource::Snapshot
+      allow(project)
+        .to receive(:non_root_file_snapshots_in_stage).and_return snapshot_class
+      allow(snapshot_class)
+        .to receive(:where).with(file_resource: [2, 3]).and_return query
+      allow(query).to receive(:pluck).with(:file_resource_id).and_return [2]
+    end
+
+    it 'removes c2 from children' do
+      subject
+      expect(children).to eq [c1, c3]
+    end
+  end
+
+  describe '#update_children_moved_into_this_folder!(children)' do
+    subject do
+      diff_children.send :update_children_moved_into_this_folder!, children
+    end
+    let(:children)  { [c1, c2, c3] }
+    let(:c1)        { instance_double Stage::FileDiff }
+    let(:c2)        { instance_double Stage::FileDiff }
+    let(:c3)        { instance_double Stage::FileDiff }
+    let(:project)   { instance_double Project }
+    let(:r3)        { instance_double Revision }
+    let(:s2)        { instance_double FileResource::Snapshot }
+
+    before do
+      allow(c1).to receive(:added?).and_return false
+      allow(c1).to receive(:file_resource_id).and_return 1
+      allow(c1).to receive(:committed_snapshot=).with(nil)
+      allow(c2).to receive(:added?).and_return true
+      allow(c2).to receive(:file_resource_id).and_return 2
+      allow(c2).to receive(:committed_snapshot=).with(s2)
+      allow(c3).to receive(:added?).and_return true
+      allow(c3).to receive(:file_resource_id).and_return 3
+      allow(c3).to receive(:committed_snapshot=).with(nil)
+
+      snapshot_class = class_double FileResource::Snapshot
+      allow(project)
+        .to receive(:revisions).and_return ['r1', 'r2', r3]
+      allow(r3).to receive(:committed_file_snapshots).and_return snapshot_class
+      allow(snapshot_class)
+        .to receive(:where).with(file_resource: [2, 3]).and_return [s2]
+      allow(s2).to receive(:file_resource_id).and_return 2
+    end
+
+    it 'keeps children intact' do
+      expect { subject }.not_to(change { children })
+    end
+
+    it 'updates c2 from children' do
+      expect(c2).to receive(:committed_snapshot=).with(s2)
+      subject
+    end
+  end
+end

--- a/spec/models/stage/file_diff_spec.rb
+++ b/spec/models/stage/file_diff_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+RSpec.describe Stage::FileDiff, type: :model do
+  subject(:diff) { build :staged_file_diff }
+
+  describe 'attributes' do
+    it { should respond_to :project }
+    it { should respond_to :project= }
+    it { should respond_to :staged_snapshot }
+    it { should respond_to :staged_snapshot= }
+    it { should respond_to :committed_snapshot }
+    it { should respond_to :committed_snapshot= }
+  end
+
+  describe '.find_by!(external_id:, project:)' do
+    subject(:find) do
+      Stage::FileDiff.find_by!(external_id: 'external-id', project: 'project')
+    end
+    let(:staged_snapshot)     { 'staged-snapshot' }
+    let(:committed_snapshot)  { 'staged-snapshot' }
+    let(:new_diff)            { instance_double described_class }
+
+    before do
+      file = instance_double FileResource
+      allow(FileResource)
+        .to receive(:find_by!).with(external_id: 'external-id').and_return file
+      allow(Stage::FileDiff)
+        .to receive(:staged_snapshot_for)
+        .with(file, 'project')
+        .and_return staged_snapshot
+      allow(Stage::FileDiff)
+        .to receive(:last_committed_snapshot_for)
+        .with(file, 'project')
+        .and_return committed_snapshot
+      allow(Stage::FileDiff)
+        .to receive(:new)
+        .with(project: 'project',
+              staged_snapshot: staged_snapshot,
+              committed_snapshot: committed_snapshot)
+        .and_return new_diff
+    end
+
+    it { is_expected.to eq new_diff }
+
+    context 'when staged_snapshot_for is nil' do
+      let(:staged_snapshot) { nil }
+      it { is_expected.to eq new_diff }
+    end
+
+    context 'when last_committed_snapshot_for is nil' do
+      let(:committed_snapshot) { nil }
+      it { is_expected.to eq new_diff }
+    end
+
+    context 'when both staged_ and last_committed_snapshot_for are nil' do
+      let(:staged_snapshot)     { nil }
+      let(:committed_snapshot)  { nil }
+      it { expect { find }.to raise_error ActiveRecord::RecordNotFound }
+    end
+  end
+
+  describe '.last_committed_snapshot_for(file, project)' do
+    subject { Stage::FileDiff.last_committed_snapshot_for('file', project) }
+    let(:project)   { instance_double Project }
+    let(:revisions) { ['r1', 'r2', revision] }
+    let(:revision)  { instance_double Revision }
+
+    before do
+      committed_snapshots = class_double FileResource::Snapshot
+      allow(project).to receive(:revisions).and_return revisions
+      allow(revision)
+        .to receive(:committed_file_snapshots).and_return committed_snapshots
+      allow(committed_snapshots)
+        .to receive(:find_by).with(file_resource: 'file').and_return 'snapshot'
+    end
+
+    it { is_expected.to eq 'snapshot' }
+
+    context 'when there is no last revision' do
+      let(:revisions) { [] }
+
+      it { is_expected.to eq nil }
+    end
+  end
+
+  describe '#initialize(attributes = {})' do
+    subject(:diff) do
+      Stage::FileDiff.new(project: 'project',
+                          file_resource_id: file_resource_id,
+                          staged_snapshot: 'staged-snapshot',
+                          committed_snapshot: 'committed-snapshot')
+    end
+    let(:file_resource_id) { 'resource-id' }
+
+    before do
+      allow_any_instance_of(Stage::FileDiff)
+        .to receive(:set_file_resource_id_from_snapshots)
+    end
+
+    it 'sets project' do
+      expect(diff.project).to eq 'project'
+    end
+
+    it 'sets file resource id' do
+      expect(diff.file_resource_id).to eq 'resource-id'
+    end
+
+    it 'sets staged_snapshot' do
+      expect(diff.staged_snapshot).to eq 'staged-snapshot'
+    end
+
+    it 'sets committed_snapshot' do
+      expect(diff.committed_snapshot).to eq 'committed-snapshot'
+    end
+
+    context 'when file_resource_id is not passed / nil' do
+      let(:file_resource_id) { nil }
+
+      it 'calls #set_file_resource_id_from_snapshots' do
+        expect_any_instance_of(Stage::FileDiff)
+          .to receive(:set_file_resource_id_from_snapshots)
+        diff
+      end
+    end
+  end
+end

--- a/spec/models/stage/file_diff_spec.rb
+++ b/spec/models/stage/file_diff_spec.rb
@@ -1,7 +1,13 @@
 # frozen_string_literal: true
 
+require 'models/shared_examples/being_diffing.rb'
+
 RSpec.describe Stage::FileDiff, type: :model do
   subject(:diff) { build :staged_file_diff }
+
+  it_should_behave_like 'being diffing' do
+    let(:diffing) { diff }
+  end
 
   describe 'attributes' do
     it { should respond_to :project }

--- a/spec/models/stage/file_diff_spec.rb
+++ b/spec/models/stage/file_diff_spec.rb
@@ -130,6 +130,23 @@ RSpec.describe Stage::FileDiff, type: :model do
     end
   end
 
+  describe '#ancestors_in_project' do
+    subject { diff.ancestors_in_project }
+
+    before do
+      allow(diff).to receive(:project).and_return 'project'
+      allow(diff)
+        .to receive(:current_or_previous_snapshot).and_return 'snapshot'
+
+      allow(Stage::FileDiff::Ancestry)
+        .to receive(:for)
+        .with(project: 'project', file_resource_snapshot: 'snapshot')
+        .and_return %w[ancestor1 ancestor2 ancestor3]
+    end
+
+    it { is_expected.to eq %w[ancestor1 ancestor2 ancestor3] }
+  end
+
   describe '#children_as_diffs' do
     subject { diff.children_as_diffs }
 
@@ -146,6 +163,30 @@ RSpec.describe Stage::FileDiff, type: :model do
     end
 
     it { is_expected.to eq 'diffs' }
+  end
+
+  describe '#first_three_ancestors' do
+    subject { diff.first_three_ancestors }
+    let(:a1) { instance_double FileResource::Snapshot }
+    let(:a2) { instance_double FileResource::Snapshot }
+    let(:a3) { instance_double FileResource::Snapshot }
+
+    before do
+      allow(diff).to receive(:project).and_return 'project'
+      allow(diff)
+        .to receive(:current_or_previous_snapshot).and_return 'snapshot'
+
+      allow(Stage::FileDiff::Ancestry)
+        .to receive(:for)
+        .with(project: 'project', file_resource_snapshot: 'snapshot', depth: 3)
+        .and_return [a1, a2, a3]
+
+      allow(a1).to receive(:name).and_return 'anc1'
+      allow(a2).to receive(:name).and_return 'anc2'
+      allow(a3).to receive(:name).and_return 'anc3'
+    end
+
+    it { is_expected.to eq %w[anc1 anc2 anc3] }
   end
 
   describe '#snapshot_id' do

--- a/spec/models/stage/file_diff_spec.rb
+++ b/spec/models/stage/file_diff_spec.rb
@@ -129,4 +129,34 @@ RSpec.describe Stage::FileDiff, type: :model do
       end
     end
   end
+
+  describe '#children_as_diffs' do
+    subject { diff.children_as_diffs }
+
+    before do
+      allow(diff).to receive(:project).and_return 'project'
+      allow(diff).to receive(:file_resource_id).and_return 'file-id'
+
+      children = instance_double Stage::FileDiff::Children
+      allow(Stage::FileDiff::Children)
+        .to receive(:new)
+        .with(project: 'project', parent_id: 'file-id')
+        .and_return children
+      allow(children).to receive(:as_diffs).and_return 'diffs'
+    end
+
+    it { is_expected.to eq 'diffs' }
+  end
+
+  describe '#snapshot_id' do
+    subject { diff.snapshot_id }
+
+    before do
+      allow(diff)
+        .to receive(:current_or_previous_snapshot_id)
+        .and_return 'current-or-previous-snapshot-id'
+    end
+
+    it { is_expected.to eq 'current-or-previous-snapshot-id' }
+  end
 end


### PR DESCRIPTION
Use Stage::FileDiff.find_by! to calculate diff for staged files and access
diffing methods (added?, changed?, ...) as well as children and ancestors.