### PR TITLE
Error pages: Do not verify authenticity token

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,6 +2,8 @@
 
 # Handles 404, 422, and 500 errors
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+
   def not_found
     render status: 404
   end


### PR DESCRIPTION
Do not verify authenticity token when rendering an error page, such as
404, 422, or 500. This is necessary, so that a POST request that triggers an
error still correctly renders errors.