### PR TITLE
Fix: Project#destroy not to raise error

### DIFF
--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -6,7 +6,10 @@ class Revision < ApplicationRecord
   belongs_to :project
   belongs_to :parent, class_name: 'Revision', optional: true, autosave: false
   belongs_to :author, class_name: 'Profiles::User'
-  has_many :committed_files, dependent: :destroy
+  has_many :children, class_name: 'Revision',
+                      foreign_key: :parent_id,
+                      dependent: :destroy
+  has_many :committed_files, dependent: :delete_all
   has_many :committed_file_snapshots, class_name: 'FileResource::Snapshot',
                                       through: :committed_files,
                                       source: :file_resource_snapshot

--- a/spec/models/revision_spec.rb
+++ b/spec/models/revision_spec.rb
@@ -15,7 +15,15 @@ RSpec.describe Revision, type: :model do
       is_expected
         .to belong_to(:author).class_name('Profiles::User').dependent(false)
     end
-    it { is_expected.to have_many(:committed_files).dependent(:destroy) }
+    it do
+      is_expected
+        .to have_many(:children)
+        .class_name('Revision')
+        .with_foreign_key(:parent_id)
+        .dependent(:destroy)
+    end
+
+    it { is_expected.to have_many(:committed_files).dependent(:delete_all) }
     it { is_expected.to have_many(:file_diffs).dependent(:destroy) }
   end
 


### PR DESCRIPTION
Set correct setting for dependent key on has_many associations on
project and revisions. This is to make sure that all associations are
successfully deleted when project is deleted and we have no foreign key
violations or orphaned records.