### PR TITLE
Add support for private projects

### DIFF
--- a/app/controllers/concerns/can_set_project_context.rb
+++ b/app/controllers/concerns/can_set_project_context.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Define setter method for setting the instance variables needed to correctly
+# display the project header and check permissions
+module CanSetProjectContext
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from CanCan::AccessDenied do |exception|
+      can_can_access_denied(exception)
+    end
+  end
+
+  private
+
+  def authorize_project_access
+    authorize! :access, @project
+  end
+
+  def can_can_access_denied(exception)
+    return unless exception.action == :access
+    flash.now.alert = exception.message
+    render 'errors/not_found', layout: 'application', status: 403
+  end
+
+  # Find and set project. Raise 404 if project does not exist
+  def set_project
+    @project = Project.find(profile_handle, profile_slug)
+  end
+
+  def profile_handle
+    params[:profile_handle]
+  end
+
+  def profile_slug
+    params[:project_slug]
+  end
+end

--- a/app/controllers/file_infos_controller.rb
+++ b/app/controllers/file_infos_controller.rb
@@ -2,7 +2,10 @@
 
 # Controller for project file infos
 class FileInfosController < ApplicationController
+  include CanSetProjectContext
+
   before_action :set_project
+  before_action :authorize_project_access
   before_action :set_staged_file_diff
   before_action :set_committed_file_diffs
   before_action :set_file
@@ -49,11 +52,6 @@ class FileInfosController < ApplicationController
       .where(revisions: { project: @project, is_published: true },
              file_resource_id: file_resource_id)
       .merge(Revision.order(id: :desc))
-  end
-
-  # Find and set project. Raise 404 if project does not exist
-  def set_project
-    @project = Project.find(params[:profile_handle], params[:project_slug])
   end
 
   def set_provider_committed_file_diffs

--- a/app/controllers/folders_controller.rb
+++ b/app/controllers/folders_controller.rb
@@ -2,7 +2,10 @@
 
 # Controller for project folders
 class FoldersController < ApplicationController
+  include CanSetProjectContext
+
   before_action :set_project
+  before_action :authorize_project_access
   before_action :set_folder_from_param, only: :show
   before_action :set_folder_from_root, only: :root
   before_action :set_children
@@ -42,11 +45,6 @@ class FoldersController < ApplicationController
 
     @folder = Stage::FileDiff.new(file_resource_id: @project.root_folder.id,
                                   project: @project)
-  end
-
-  # Find and set project. Raise 404 if project does not exist
-  def set_project
-    @project = Project.find(params[:profile_handle], params[:project_slug])
   end
 
   def set_provider_for_children

--- a/app/controllers/revisions_controller.rb
+++ b/app/controllers/revisions_controller.rb
@@ -2,8 +2,11 @@
 
 # Controller for project revisions
 class RevisionsController < ApplicationController
+  include CanSetProjectContext
+
   before_action :authenticate_account!, except: :index
   before_action :set_project
+  before_action :authorize_project_access
   before_action :authorize_action, except: :index
   before_action :build_revision, only: :new
   before_action :find_revision, only: :create
@@ -41,7 +44,7 @@ class RevisionsController < ApplicationController
   private
 
   rescue_from CanCan::AccessDenied do |exception|
-    redirect_to [@project.owner, @project], alert: exception.message
+    can_can_access_denied(exception)
   end
 
   def authorize_action
@@ -50,6 +53,10 @@ class RevisionsController < ApplicationController
 
   def build_revision
     @revision = @project.revisions.create_draft_and_commit_files!(current_user)
+  end
+
+  def can_can_access_denied(exception)
+    super || redirect_to([@project.owner, @project], alert: exception.message)
   end
 
   def find_revision
@@ -71,11 +78,6 @@ class RevisionsController < ApplicationController
     @file_diffs.each do |diff|
       diff.provider = @project.root_folder.provider
     end
-  end
-
-  # Find and set project. Raise 404 if project does not exist
-  def set_project
-    @project = Project.find(params[:profile_handle], params[:project_slug])
   end
 
   def revision_params

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -137,6 +137,10 @@ class Project < ApplicationRecord
     @google_drive_folder_id = folder_link_to_id(link)
   end
 
+  def public?
+    is_public
+  end
+
   # List of tags, separated by comma
   def tag_list
     tags.join(', ')

--- a/app/views/projects/new.slim
+++ b/app/views/projects/new.slim
@@ -7,19 +7,26 @@
           h1 New Project
 
   .container
-   - if @project.errors.any?
-     .row
-       .col.s12
-         .validation-errors
-           = render partial: "error", collection: @project.errors.full_messages, as: :error
+    - if @project.errors.any?
+      .row
+        .col.s12
+          .validation-errors
+            = render partial: "error", collection: @project.errors.full_messages, as: :error
 
-   .row
-     .col.s12.l12
-       .input-field
-         h2.no-margin
-          = f.text_field :title, placeholder: 'Title', class: 'inherit'
+    .row
+      .col.s12.l12
+        .input-field
+          h2.no-margin
+            = f.text_field :title, placeholder: 'Title', class: 'inherit'
+    .row
+      .col.s12
+        p
+          | Projects are private by default. Only you (and any collaborators
+            you add to your projects) will be able to see files, changes, and
+            summaries.
+        .spacing.v16px
 
-   .row
-     .col.s12
-       button action='submit' class="btn-large primary-color primary-color-text"
-         | Create
+    .row
+      .col.s12
+        button action='submit' class="btn-large primary-color primary-color-text"
+          | Create

--- a/db/migrate/20180307044915_add_is_public_to_projects.rb
+++ b/db/migrate/20180307044915_add_is_public_to_projects.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add support for public and private projects
+class AddIsPublicToProjects < ActiveRecord::Migration[5.1]
+  def change
+    add_column :projects, :is_public, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227150638) do
+ActiveRecord::Schema.define(version: 20180307044915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 20180227150638) do
     t.citext "slug", null: false
     t.text "description"
     t.citext "tags", default: [], array: true
+    t.boolean "is_public", default: false, null: false
     t.index ["owner_type", "owner_id", "slug"], name: "index_projects_on_owner_type_and_owner_id_and_slug", unique: true
     t.index ["owner_type", "owner_id"], name: "index_projects_on_owner_type_and_owner_id"
   end

--- a/spec/controllers/file_infos_controller_spec.rb
+++ b/spec/controllers/file_infos_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
+require 'controllers/shared_examples/authorizing_project_access.rb'
 
 RSpec.describe FileInfosController, type: :controller do
   let(:root)    { create :file_resource, :folder }
@@ -13,8 +14,9 @@ RSpec.describe FileInfosController, type: :controller do
       id:             folder.external_id
     }
   end
-
-  before { project.root_folder = root }
+  let(:current_account) { project.owner.account }
+  before                { sign_in current_account }
+  before                { project.root_folder = root }
 
   describe 'GET #index' do
     let(:params)      { default_params }
@@ -26,6 +28,7 @@ RSpec.describe FileInfosController, type: :controller do
       # when file does not exist and never has
       before { default_params[:id] = 'some-nonexistent-id' }
     end
+    it_should_behave_like 'authorizing project access'
 
     context 'when id is of root folder' do
       before      { params[:id] = root.external_id }

--- a/spec/controllers/folders_controller_spec.rb
+++ b/spec/controllers/folders_controller_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
+require 'controllers/shared_examples/authorizing_project_access.rb'
 
 RSpec.describe FoldersController, type: :controller do
   let(:root)    { create :file_resource, :folder }
@@ -13,18 +14,20 @@ RSpec.describe FoldersController, type: :controller do
       id:             folder.external_id
     }
   end
-
-  before { project.root_folder = root }
+  let(:current_account) { project.owner.account }
+  before                { sign_in current_account }
+  before                { project.root_folder = root }
 
   describe 'GET #root' do
-    let(:params)      { default_params.except :id }
-    let(:run_request) { get :root, params: params }
+    let(:params)          { default_params.except :id }
+    let(:run_request)     { get :root, params: params }
 
     it_should_behave_like 'raise 404 if non-existent', Profiles::Base
     it_should_behave_like 'raise 404 if non-existent', Project
     it_should_behave_like 'raise 404 if non-existent', nil do
       before { StagedFile.delete_all }
     end
+    it_should_behave_like 'authorizing project access'
 
     it 'returns http success' do
       run_request
@@ -33,14 +36,15 @@ RSpec.describe FoldersController, type: :controller do
   end
 
   describe 'GET #show' do
-    let(:params)      { default_params }
-    let(:run_request) { get :show, params: params }
+    let(:params)          { default_params }
+    let(:run_request)     { get :show, params: params }
 
     it_should_behave_like 'raise 404 if non-existent', Profiles::Base
     it_should_behave_like 'raise 404 if non-existent', Project
     it_should_behave_like 'raise 404 if non-existent', nil do
       before { StagedFile.delete_all }
     end
+    it_should_behave_like 'authorizing project access'
 
     context 'when file is not a directory' do
       let(:file)  { create :file_resource, parent: folder }

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -3,6 +3,7 @@
 require 'controllers/shared_examples/a_redirect_with_success.rb'
 require 'controllers/shared_examples/an_authenticated_action.rb'
 require 'controllers/shared_examples/an_authorized_action.rb'
+require 'controllers/shared_examples/authorizing_project_access.rb'
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
 
 RSpec.describe ProjectsController, type: :controller do
@@ -126,11 +127,14 @@ RSpec.describe ProjectsController, type: :controller do
   end
 
   describe 'GET #show' do
-    let(:params)      { default_params }
-    let(:run_request) { get :show, params: params }
+    let(:params)          { default_params }
+    let(:run_request)     { get :show, params: params }
+    let(:current_account) { project.owner.account }
+    before                { sign_in current_account }
 
     include_examples 'raise 404 if non-existent', Profiles::Base
     include_examples 'raise 404 if non-existent', Project
+    it_should_behave_like 'authorizing project access'
 
     it 'returns http success' do
       run_request

--- a/spec/controllers/revisions_controller_spec.rb
+++ b/spec/controllers/revisions_controller_spec.rb
@@ -3,6 +3,7 @@
 require 'controllers/shared_examples/a_redirect_with_success.rb'
 require 'controllers/shared_examples/an_authenticated_action.rb'
 require 'controllers/shared_examples/an_authorized_action.rb'
+require 'controllers/shared_examples/authorizing_project_access.rb'
 require 'controllers/shared_examples/raise_404_if_non_existent.rb'
 require 'controllers/shared_examples/successfully_rendering_view.rb'
 
@@ -14,6 +15,8 @@ RSpec.describe RevisionsController, type: :controller do
       project_slug:   project.slug
     }
   end
+  let(:current_account) { project.owner.account }
+  before                { sign_in current_account }
 
   describe 'GET #index' do
     let(:params)      { default_params }
@@ -21,6 +24,7 @@ RSpec.describe RevisionsController, type: :controller do
 
     it_should_behave_like 'raise 404 if non-existent', Profiles::Base
     it_should_behave_like 'raise 404 if non-existent', Project
+    it_should_behave_like 'authorizing project access'
 
     it 'returns http success' do
       run_request
@@ -31,7 +35,6 @@ RSpec.describe RevisionsController, type: :controller do
   describe 'GET #new' do
     let(:params)      { default_params }
     let(:run_request) { get :new, params: params }
-    before            { sign_in project.owner.account }
 
     it_should_behave_like 'an authenticated action'
     it_should_behave_like 'raise 404 if non-existent', Profiles::Base
@@ -42,6 +45,7 @@ RSpec.describe RevisionsController, type: :controller do
         'You are not authorized to commit changes for this project.'
       end
     end
+    it_should_behave_like 'authorizing project access'
 
     it 'returns http success' do
       run_request
@@ -51,10 +55,9 @@ RSpec.describe RevisionsController, type: :controller do
 
   describe 'POST #create' do
     let!(:revision_draft) { create :revision, project: project, author: author }
-    let(:author)          { project.owner }
+    let(:author)          { current_account.user }
     let(:params)          { default_params.merge(add_params) }
     let(:run_request)     { post :create, params: params }
-    before                { sign_in project.owner.account }
     let(:add_params) do
       {
         revision: {
@@ -79,6 +82,7 @@ RSpec.describe RevisionsController, type: :controller do
         profile_project_root_folder_path(project.owner, project)
       end
     end
+    it_should_behave_like 'authorizing project access'
 
     it 'publishes the revision' do
       expect_any_instance_of(Revision)

--- a/spec/controllers/shared_examples/an_authorized_action.rb
+++ b/spec/controllers/shared_examples/an_authorized_action.rb
@@ -4,6 +4,8 @@
 RSpec.shared_examples 'an authorized action' do
   let(:has_ability) { false }
   before do
+    allow(controller).to receive(:authorize!).and_call_original
+    allow(controller).to receive(:authorize!).with(:access, any_args)
     allow_any_instance_of(Ability).to receive(:can?).and_return has_ability
     run_request
   end

--- a/spec/controllers/shared_examples/authorizing_project_access.rb
+++ b/spec/controllers/shared_examples/authorizing_project_access.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+# Expect the action to authorize project access with CanCanCan
+RSpec.shared_examples 'authorizing project access' do
+  let(:can_access) { false }
+  before do
+    allow_any_instance_of(Ability).to receive(:can?).and_call_original
+    allow_any_instance_of(Ability)
+      .to receive(:can?).with(:access, project).and_return can_access
+    run_request
+  end
+
+  context 'when user can access project' do
+    let(:can_access) { true }
+
+    it 'does not have forbidden HTTP status' do
+      run_request
+      expect(response).not_to have_http_status :forbidden
+    end
+  end
+
+  context 'when user cannot access project' do
+    let(:can_access) { false }
+
+    it 'has forbidden HTTP status with unauthorized message' do
+      run_request
+      expect(response).to have_http_status :forbidden
+      is_expected.to set_flash.now[:alert].to(
+        'You are not authorized to access this project.'
+      )
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -9,5 +9,6 @@ FactoryGirl.define do
     tags            { Faker::Lorem.words }
     sequence(:slug) { |n| "project-slug-#{n}" }
     owner           { build(:user) }
+    is_public       { false }
   end
 end

--- a/spec/features/collaborator_spec.rb
+++ b/spec/features/collaborator_spec.rb
@@ -17,6 +17,24 @@ feature 'Collaborators' do
     expect(page).to have_text project.title
   end
 
+  scenario 'As a collaborator, I can view a private project' do
+    # given there is a project
+    project = create :project
+    # and I am signed in as a user
+    me = create :user
+    sign_in_as me.account
+    # who is added to that project's Collaborators
+    project.collaborators << me
+
+    # when I visit the project page
+    visit "#{project.owner.to_param}/#{project.to_param}"
+
+    # then I should be on the project's page
+    expect(page).to have_current_path(
+      "/#{project.owner.to_param}/#{project.to_param}"
+    )
+  end
+
   scenario 'As a collaborator, I can create a new revision' do
     # given there is a project
     project = create :project

--- a/spec/features/file_info_spec.rb
+++ b/spec/features/file_info_spec.rb
@@ -4,6 +4,7 @@ feature 'File Info' do
   let(:project) { create :project }
   let(:root)    { create :file_resource, :folder }
   before { project.root_folder = root }
+  before { sign_in_as project.owner.account }
 
   scenario 'User can see file info' do
     # given there is a file and it is committed

--- a/spec/features/file_update_spec.rb
+++ b/spec/features/file_update_spec.rb
@@ -39,6 +39,8 @@ feature 'File Update', :vcr do
     r.update(is_published: true, title: 'origin revision')
   end
 
+  before { sign_in_as project.owner.account }
+
   scenario 'In Google Drive, user creates file within project folder' do
     given_project_is_imported_and_changes_committed
 

--- a/spec/features/folder_spec.rb
+++ b/spec/features/folder_spec.rb
@@ -14,6 +14,8 @@ feature 'Folder' do
     files
   end
 
+  before { sign_in_as project.owner.account }
+
   scenario 'User can view root-folder' do
     # when I visit the project page
     visit "#{project.owner.to_param}/#{project.to_param}"

--- a/spec/features/project_spec.rb
+++ b/spec/features/project_spec.rb
@@ -31,6 +31,8 @@ feature 'Project' do
     # with two collaborators
     collaborators = create_list :user, 2
     project.collaborators << collaborators
+    # and I am signed in as the project owner
+    sign_in_as project.owner.account
 
     # when I visit the project's owner
     visit "/#{project.owner.to_param}"

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -10,7 +10,9 @@ feature 'Revision' do
   end
 
   scenario 'User can see past revisions' do
-    # given there is a file
+    # given I am signed in as the project owner
+    sign_in_as project.owner.account
+    # and there is a file
     file = create :file_resource, name: 'File1', parent: root
     # with three revisions made by three different users
     users = create_list :user, 3

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -18,6 +18,39 @@ RSpec.describe Ability, type: :model do
   subject(:ability) { Ability.new(user) }
   let(:user) { create(:user) }
 
+  context 'Project Access' do
+    actions = %i[access]
+    let(:object)  { project }
+    let(:project) { build_stubbed(:project) }
+
+    context 'when project is public' do
+      let(:user) { nil }
+      before { project.is_public = true }
+      it_should_behave_like 'having authorization', actions
+    end
+
+    context 'when user is not signed in' do
+      let(:user) { nil }
+      it_should_behave_like 'not having authorization', actions
+    end
+
+    context 'when user is not project owner or collaborator' do
+      before { project.owner = build_stubbed(:user) }
+      before { project.collaborators = [] }
+      it_should_behave_like 'not having authorization', actions
+    end
+
+    context 'when user is project owner' do
+      before { project.owner = user }
+      it_should_behave_like 'having authorization', actions
+    end
+
+    context 'when user is collaborator' do
+      before { project.collaborators << user }
+      it_should_behave_like 'having authorization', actions
+    end
+  end
+
   context 'Users' do
     actions = %i[manage]
     let(:object) { build_stubbed(:user) }

--- a/spec/views/projects/new_spec.rb
+++ b/spec/views/projects/new_spec.rb
@@ -25,6 +25,11 @@ RSpec.describe 'projects/new', type: :view do
     expect(rendered).to have_css 'input#project_title'
   end
 
+  it 'informs user that projects are private' do
+    render
+    expect(rendered).to have_text 'Projects are private'
+  end
+
   it 'has a button to create the project' do
     render
     expect(rendered)


### PR DESCRIPTION
Projects can be private (accessible only by owner and collaborators) or public (accessible by everyone). Projects are private by default.