### PR TITLE
Use language: Capture Changes

### DIFF
--- a/app/models/revision.rb
+++ b/app/models/revision.rb
@@ -66,9 +66,9 @@ class Revision < ApplicationRecord
   def can_only_have_one_revision_with_parent
     return unless published_revision_with_parent_exists?
     errors.add(:base,
-               'Someone has committed changes to this project since you ' \
+               'Someone has captured changes to this project since you ' \
                'started reviewing changes. To prevent you and your team from ' \
-               "overwriting each other's changes, you cannot commit the " \
+               "overwriting each other's changes, you cannot capture the " \
                'changes you are currently reviewing.')
   end
 

--- a/app/views/file_infos/_new_file_changes.slim
+++ b/app/views/file_infos/_new_file_changes.slim
@@ -1,6 +1,10 @@
 / render list of current file changes, if any
 
-h3.with-separator: span New Changes (uncommitted)
+h3.with-separator
+  span
+    ' New Changes
+    small
+      | (since last revision)
 
 - if staged_file_diff.changes.any?
 

--- a/app/views/folders/show.slim
+++ b/app/views/folders/show.slim
@@ -28,6 +28,6 @@
 / button for committing changes
 - if @user_can_commit_changes
   .fixed-action-btn
-    = link_to 'Commit Changes',
+    = link_to 'Capture Changes',
         new_profile_project_revision_path(@project.owner, @project),
         class: 'btn btn-large primary-color primary-color-text'

--- a/app/views/revisions/new.slim
+++ b/app/views/revisions/new.slim
@@ -4,7 +4,7 @@
     .container
       .row.no-margin-bottom
         .col.s12
-          h2 Commit Changes
+          h2 Capture Changes
 
   .container
     - if @revision.errors.any?
@@ -35,7 +35,7 @@
     .row
       .col.s12.right-align
         button action='submit' class="btn-large primary-color primary-color-text"
-          | Commit Changes
+          | Capture Changes
 
     .spacing.v1
 

--- a/spec/features/collaborator_spec.rb
+++ b/spec/features/collaborator_spec.rb
@@ -52,12 +52,12 @@ feature 'Collaborators' do
     visit "#{project.owner.to_param}/#{project.to_param}"
     # and click on Files
     click_on 'Files'
-    # and click on Commit Changes
-    click_on 'Commit Changes'
+    # and click on Capture Changes
+    click_on 'Capture Changes'
     # and enter a revision title
-    fill_in 'Title', with: 'Initial Commit'
-    # and click on 'Commit'
-    click_on 'Commit'
+    fill_in 'Title', with: 'Initial Capture'
+    # and click on 'Capture'
+    click_on 'Capture'
 
     # then I should be on the project's files page
     expect(page).to have_current_path(

--- a/spec/features/revision_spec.rb
+++ b/spec/features/revision_spec.rb
@@ -53,12 +53,12 @@ feature 'Revision' do
     visit "#{project.owner.to_param}/#{project.to_param}"
     # and click on Files
     click_on 'Files'
-    # and click on Commit Changes
-    click_on 'Commit Changes'
+    # and click on Capture Changes
+    click_on 'Capture Changes'
     # and enter a revision title
-    fill_in 'Title', with: 'Initial Commit'
-    # and click on 'Commit'
-    click_on 'Commit'
+    fill_in 'Title', with: 'Initial Capture'
+    # and click on 'Capture'
+    click_on 'Capture'
 
     # then I should be on the project's files page
     expect(page).to have_current_path(
@@ -102,8 +102,8 @@ feature 'Revision' do
     visit "#{project.owner.to_param}/#{project.to_param}"
     # and click on Files
     click_on 'Files'
-    # and click on Commit Changes
-    click_on 'Commit Changes'
+    # and click on Capture Changes
+    click_on 'Capture Changes'
 
     # then I can see the changes I am about to commit
     expect(page).to have_css '.file.added',     text: added_file.name

--- a/spec/views/file_infos/index_spec.rb
+++ b/spec/views/file_infos/index_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'file_infos/index', type: :view do
 
     it 'renders that the file has been unchanged since the last revision' do
       render
-      expect(rendered).to have_text 'New Changes (uncommitted)'
+      expect(rendered).to have_text 'New Changes (since last revision)'
       expect(rendered).to have_text(
         'No changes have been made to this file since the last revision'
       )
@@ -90,14 +90,14 @@ RSpec.describe 'file_infos/index', type: :view do
       end
     end
 
-    context 'when staged file diff has uncommitted changes' do
+    context 'when staged file diff has uncaptured changes' do
       before do
         allow(staged_file_diff).to receive(:changes)
           .and_return %i[added modified moved renamed deleted]
         allow(staged_file_diff).to receive(:ancestor_path).and_return 'Home'
       end
 
-      it 'renders uncommitted changes' do
+      it 'renders uncaptured changes' do
         render
         expect(rendered).to have_text 'My Document added to Home'
         expect(rendered).to have_text(

--- a/spec/views/folders/show_spec.rb
+++ b/spec/views/folders/show_spec.rb
@@ -78,10 +78,10 @@ RSpec.describe 'folders/show', type: :view do
     end
   end
 
-  it 'does not have a button to commit changes' do
+  it 'does not have a button to capture changes' do
     render
     expect(rendered).not_to have_link(
-      'Commit Changes',
+      'Capture Changes',
       href: new_profile_project_revision_path(project.owner, project)
     )
   end
@@ -89,10 +89,10 @@ RSpec.describe 'folders/show', type: :view do
   context 'when current user can edit project' do
     before { assign(:user_can_commit_changes, true) }
 
-    it 'has a button to commit changes' do
+    it 'has a button to capture changes' do
       render
       expect(rendered).to have_link(
-        'Commit Changes',
+        'Capture Changes',
         href: new_profile_project_revision_path(project.owner, project)
       )
     end

--- a/spec/views/revisions/new_spec.rb
+++ b/spec/views/revisions/new_spec.rb
@@ -46,10 +46,10 @@ RSpec.describe 'revisions/new', type: :view do
     expect(rendered).to have_css 'textarea#revision_summary'
   end
 
-  it 'has a button to commit changes' do
+  it 'has a button to capture changes' do
     render
     expect(rendered)
-      .to have_css "button[action='submit']", text: 'Commit Changes'
+      .to have_css "button[action='submit']", text: 'Capture Changes'
   end
 
   it 'lets the user know that there are no changes to review' do


### PR DESCRIPTION
Replace any occurrence of 'Commit Changes' with 'Capture Changes'. Commit
is a word specific to the programming community and is generally
confusing to others. We will see if the idea of capturing changes is a
bit more clear.