### PR TITLE
Fix Ahoy: Provide class name for user association

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -8,6 +8,6 @@ module Ahoy
     self.table_name = 'ahoy_events'
 
     belongs_to :visit
-    belongs_to :user, optional: true
+    belongs_to :user, class_name: 'Profiles::User', optional: true
   end
 end

--- a/app/models/ahoy/visit.rb
+++ b/app/models/ahoy/visit.rb
@@ -6,7 +6,7 @@ module Ahoy
   class Visit < ApplicationRecord
     self.table_name = 'ahoy_visits'
 
-    has_many :events, class_name: 'Ahoy::Event'
-    belongs_to :user, optional: true
+    has_many :events, class_name: 'Ahoy::Event', dependent: :delete_all
+    belongs_to :user, class_name: 'Profiles::User', optional: true
   end
 end

--- a/spec/models/ahoy/event_spec.rb
+++ b/spec/models/ahoy/event_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Ahoy::Event, type: :model do
+  subject(:visit) { Ahoy::Event.new }
+
+  describe 'associations' do
+    it do
+      is_expected
+        .to belong_to(:visit).class_name('Ahoy::Visit').dependent(false)
+    end
+    it do
+      is_expected
+        .to belong_to(:user).class_name('Profiles::User').dependent(false)
+    end
+  end
+end

--- a/spec/models/ahoy/visit_spec.rb
+++ b/spec/models/ahoy/visit_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe Ahoy::Visit, type: :model do
+  subject(:visit) { Ahoy::Visit.new }
+
+  describe 'associations' do
+    it do
+      is_expected
+        .to have_many(:events).class_name('Ahoy::Event').dependent(:delete_all)
+    end
+    it do
+      is_expected
+        .to belong_to(:user).class_name('Profiles::User').dependent(false)
+    end
+  end
+end


### PR DESCRIPTION
Provide the class name (Profiles::User) for the user association on Ahoy
models Visit and Event, because the class name cannot be inferred from
the association name.