### PR TITLE
Project: Remove polymorphism from owner association

### DIFF
--- a/app/models/profiles/base.rb
+++ b/app/models/profiles/base.rb
@@ -19,7 +19,9 @@ module Profiles
     end
 
     # Associations
-    has_many :projects, as: :owner, dependent: :destroy, inverse_of: :owner
+    has_many :projects, foreign_key: :owner_id,
+                        dependent: :destroy,
+                        inverse_of: :owner
     has_and_belongs_to_many :collaborations, class_name: 'Project',
                                              foreign_key: 'profile_id',
                                              validate: false

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,7 +4,7 @@
 # rubocop:disable Metrics/ClassLength
 class Project < ApplicationRecord
   # Associations
-  belongs_to :owner, polymorphic: true
+  belongs_to :owner, class_name: 'Profiles::Base'
   has_and_belongs_to_many :collaborators, class_name: 'Profiles::User',
                                           association_foreign_key: 'profile_id',
                                           validate: false
@@ -78,10 +78,8 @@ class Project < ApplicationRecord
   }
 
   # Validations
-  # Owner type must be user
-  validates :owner_type, inclusion: { in: %w[Profiles::Base] }
+  # Title & slug must be present
   validates :title, presence: true, length: { maximum: 50 }
-  # Slug must be present
   validates :slug, presence: true
   # Conduct validations only if slug is present
   with_options if: :slug? do
@@ -111,7 +109,7 @@ class Project < ApplicationRecord
   validates :slug,
             uniqueness: {
               case_sensitive: true,
-              scope: %i[owner_type owner_id]
+              scope: :owner_id
             },
             unless: proc { |project| project.errors[:slug].any? }
   validate :link_to_google_drive_folder_is_valid,

--- a/db/migrate/20180314010314_remove_owner_type_from_projects.rb
+++ b/db/migrate/20180314010314_remove_owner_type_from_projects.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Remove owner_type column from projects table (because it no longer needs to be
+# a polymorphic association)
+class RemoveOwnerTypeFromProjects < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :projects, :owner_type
+    add_index :projects, :owner_id
+    add_index :projects, %i[owner_id slug], unique: true
+  end
+
+  def down
+    remove_reference :projects, :owner
+    add_reference :projects, :owner, polymorphic: true, null: false
+    add_index :projects, %i[owner_type owner_id slug], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180307134226) do
+ActiveRecord::Schema.define(version: 20180314010314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -163,16 +163,15 @@ ActiveRecord::Schema.define(version: 20180307134226) do
 
   create_table "projects", force: :cascade do |t|
     t.string "title", null: false
-    t.string "owner_type", null: false
-    t.bigint "owner_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.citext "slug", null: false
     t.text "description"
     t.citext "tags", default: [], array: true
     t.boolean "is_public", default: false, null: false
-    t.index ["owner_type", "owner_id", "slug"], name: "index_projects_on_owner_type_and_owner_id_and_slug", unique: true
-    t.index ["owner_type", "owner_id"], name: "index_projects_on_owner_type_and_owner_id"
+    t.bigint "owner_id", null: false
+    t.index ["owner_id", "slug"], name: "index_projects_on_owner_id_and_slug", unique: true
+    t.index ["owner_id"], name: "index_projects_on_owner_id"
   end
 
   create_table "revisions", force: :cascade do |t|

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Project, type: :model do
   end
 
   describe 'associations' do
-    it { is_expected.to belong_to(:owner) }
+    it { is_expected.to belong_to(:owner).class_name('Profiles::Base') }
     it do
       is_expected
         .to have_and_belong_to_many(:collaborators)
@@ -132,56 +132,15 @@ RSpec.describe Project, type: :model do
     it do
       is_expected.to validate_presence_of(:owner).with_message 'must exist'
     end
-    it do
-      is_expected
-        .to validate_inclusion_of(:owner_type).in_array %w[Profiles::Base]
-    end
     it { is_expected.to validate_presence_of(:title) }
     it { is_expected.to validate_length_of(:title).is_at_most(50) }
 
     context 'when validating slug' do
-      # Test does not work with polymorphic associations, use custom test below
-      # instead
-      # it do
-      #   is_expected
-      #     .to validate_uniqueness_of(:slug)
-      #     .case_insensitive
-      #     .scoped_to(:owner_type, :owner_id)
-      # end
-      context 'uniqueness of slug scoped to owner type + ID' do
-        let!(:first_project)      { create :project, slug: slug, owner: owner }
-        let(:slug)  { 'my-slug' }
-        let(:owner) { create(:user) }
-
-        context 'when owner type is identical but ID is different' do
-          subject(:second_project)  { build :project, slug: slug }
-          before                    { second_project.valid? }
-          it 'does not add a :slug error' do
-            expect(second_project.errors[:slug])
-              .not_to include 'has already been taken'
-          end
-        end
-
-        context 'when owner ID is identical but type is different' do
-          subject(:second_project) { build :project, slug: slug, owner: owner }
-          before do
-            second_project.owner_type = 'Project'
-            second_project.valid?
-          end
-          it 'does not add a :slug error' do
-            expect(second_project.errors[:slug])
-              .not_to include 'has already been taken'
-          end
-        end
-
-        context 'when owner ID + type are identical' do
-          subject(:second_project)  { build :project, slug: slug, owner: owner }
-          before                    { second_project.valid? }
-          it 'adds a :slug error' do
-            expect(second_project.errors[:slug])
-              .to include 'has already been taken'
-          end
-        end
+      it do
+        is_expected
+          .to validate_uniqueness_of(:slug)
+          .scoped_to(:owner_id)
+          .case_insensitive
       end
 
       it do

--- a/spec/models/shared_examples/being_a_profile.rb
+++ b/spec/models/shared_examples/being_a_profile.rb
@@ -12,7 +12,11 @@ RSpec.shared_examples 'being a profile' do
 
   describe 'associations' do
     it do
-      is_expected.to have_many(:projects).dependent(:destroy).inverse_of :owner
+      is_expected
+        .to have_many(:projects)
+        .with_foreign_key(:owner_id)
+        .dependent(:destroy)
+        .inverse_of(:owner)
     end
     it do
       is_expected


### PR DESCRIPTION
Make project's owner association non-polymorphic. The polymorphic
association was necessary when we had different models & tables for
users and teams, but since they both share the profiles table, we can
remove the polymorphic association.