### PR TITLE
Add accounts:create_from_csv task

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -84,6 +84,17 @@ namespace :paperclip do
   end
 end
 
+desc 'Invoke a rake command on the remote server'
+task :invoke, [:command] => 'deploy:set_rails_env' do |_task, args|
+  on roles(:app) do
+    within release_path do
+      with rails_env: fetch(:rails_env) do
+        rake args[:command]
+      end
+    end
+  end
+end
+
 namespace :deploy do
   desc 'Make sure local git is in sync with remote.'
   task :check_revision do

--- a/lib/tasks/accounts/create_from_csv.rake
+++ b/lib/tasks/accounts/create_from_csv.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Create accounts from data passed in a CSV file
+# CSV file must have columns :email, :password, :name, and :handle
+# Pass path to CSV file when invoking task:
+# rake accounts:create_from_csv['path']
+desc 'Accounts: Create from CSV file'
+namespace :accounts do
+  task :create_from_csv, [:file_path] => :environment do |_task, args|
+    require 'csv'
+
+    CSV.foreach(args[:file_path], headers: true) do |row|
+      values = row.to_hash.symbolize_keys
+      puts "Creating account for #{values[:email]}..."
+      a = Account.new(values.slice(:email, :password))
+      a.build_user(values.slice(:name, :handle))
+      a.save!
+    end
+  end
+end

--- a/spec/lib/shared_contexts/rake.rb
+++ b/spec/lib/shared_contexts/rake.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rake'
+
+shared_context 'rake' do
+  let(:rake)      { Rake::Application.new }
+  let(:task_name) { self.class.top_level_description }
+  let(:task_path) { "lib/tasks/#{task_name.split(':').first}" }
+  subject         { rake[task_name] }
+
+  def loaded_files_excluding_current_rake_file
+    $LOADED_FEATURES
+      .reject { |file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(
+      task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file
+    )
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/lib/tasks/accounts_create_from_csv_spec.rb
+++ b/spec/lib/tasks/accounts_create_from_csv_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'lib/shared_contexts/rake.rb'
+
+RSpec.describe 'accounts:create_from_csv' do
+  include_context 'rake'
+
+  let(:task_path)   { "lib/tasks/#{task_name.tr(':', '/')}" }
+  let(:path_to_csv) { 'spec/support/fixtures/accounts/import.csv' }
+
+  let(:account1)    { Account.find_by_email('a1@example.com') }
+  let(:account2)    { Account.find_by_email('a2@example.com') }
+  let(:account3)    { Account.find_by_email('a3@example.com') }
+
+  before { allow(STDOUT).to receive(:puts) }
+  before { subject.invoke(path_to_csv) }
+
+  it 'creates three users' do
+    expect(Account.count).to eq 3
+
+    expect(account1).to be_valid_password 'a1password'
+    expect(account1.user.name).to eq 'Account 1 Name'
+    expect(account1.user.handle).to eq 'account1'
+
+    expect(account2).to be_valid_password 'a2password'
+    expect(account2.user.name).to eq '2nd Account Name'
+    expect(account2.user.handle).to eq 'accountnrtwo'
+
+    expect(account3).to be_valid_password 'a3password'
+    expect(account3.user.name).to eq 'Third Account'
+    expect(account3.user.handle).to eq '3rdaccount'
+  end
+end

--- a/spec/support/fixtures/accounts/import.csv
+++ b/spec/support/fixtures/accounts/import.csv
@@ -1,0 +1,4 @@
+name,email,handle,password
+Account 1 Name,a1@example.com,account1,a1password
+2nd Account Name,a2@example.com,accountnrtwo,a2password
+Third Account,a3@example.com,3rdaccount,a3password


### PR DESCRIPTION
Add task for importing accounts from a csv file. Path to file must be passed as the argument to the task:
rake accounts:create_from_csv['path']
And the csv file must have the headers name, email, password, and handle.