### PR TITLE
Add custom page for unauthorized access to project

### DIFF
--- a/app/controllers/concerns/can_set_project_context.rb
+++ b/app/controllers/concerns/can_set_project_context.rb
@@ -20,7 +20,7 @@ module CanSetProjectContext
   def can_can_access_denied(exception)
     return unless exception.action == :access
     flash.now.alert = exception.message
-    render 'errors/not_found', layout: 'application', status: 403
+    render 'projects/access_unauthorized', layout: 'application', status: 403
   end
 
   # Find and set project. Raise 404 if project does not exist

--- a/app/views/projects/access_unauthorized.slim
+++ b/app/views/projects/access_unauthorized.slim
@@ -1,0 +1,32 @@
+.spacing.v64px
+
+.not-found.container.center-align
+
+  .row
+    .col.s12
+      svg.icon viewBox="0 0 24 24"
+        path fill="currentColor" d="M12,17C10.89,17 10,16.1 10,15C10,13.89 10.89,13 12,13A2,2 0 0,1 14,15A2,2 0 0,1 12,17M18,20V10H6V20H18M18,8A2,2 0 0,1 20,10V20A2,2 0 0,1 18,22H6C4.89,22 4,21.1 4,20V10C4,8.89 4.89,8 6,8H7V6A5,5 0 0,1 12,1A5,5 0 0,1 17,6V8H18M12,3A3,3 0 0,0 9,6V8H15V6A3,3 0 0,0 12,3Z"
+
+  .row
+    .col.s12
+      h1 Hi there!
+      p.flow-text
+        | You are not authorized to access this project.
+        br
+        br
+        - if account_signed_in?
+          | Ask the owner to add you as a project collaborator.
+        - else
+          => link_to 'Log in', new_session_path
+          | and try again.
+
+  .row
+    .col.s12
+      .divider
+
+  .row
+    .col.s12
+      p
+        | Prejudice is a burden that confuses the past, threatens the future and renders the present inaccessible.
+        br
+        em - Maya Angelou

--- a/spec/views/projects/access_unauthorized_spec.rb
+++ b/spec/views/projects/access_unauthorized_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe 'projects/access_unauthorized', type: :view do
+  let(:account_signed_in) { true }
+
+  before do
+    allow(view).to receive(:account_signed_in?).and_return account_signed_in
+  end
+
+  it 'tells the user that they are not authorized to access the project' do
+    render
+    expect(rendered).to have_text 'not authorized to access'
+  end
+
+  it 'tells the user to ask owner to be added as a collaborator' do
+    render
+    expect(rendered)
+      .to have_text 'Ask the owner to add you as a project collaborator.'
+  end
+
+  context 'when user is not logged in' do
+    let(:account_signed_in) { false }
+
+    it 'has a link to log in' do
+      render
+      expect(rendered).to have_link href: new_session_path, text: 'Log in'
+    end
+  end
+end


### PR DESCRIPTION
Show custom access-unauthorized error page when user tries to access a project for which they are unauthorized.