### PR TITLE
Fix: Input .inherit inherits color

### DIFF
--- a/app/assets/stylesheets/shared/forms.scss
+++ b/app/assets/stylesheets/shared/forms.scss
@@ -30,6 +30,7 @@ input[type='text'] {
   &.inherit {
     // scss-lint:disable ImportantRule
     box-shadow: none !important;
+    color: inherit;
     font-size: inherit;
     height: auto;
     line-height: inherit;


### PR DESCRIPTION
Inputs with .inherit class now inherit their parent element's color style.