### PR TITLE
Fix: Folder spec

### DIFF
--- a/spec/features/folder_spec.rb
+++ b/spec/features/folder_spec.rb
@@ -65,7 +65,8 @@ feature 'Folder' do
     click_on 'Files'
 
     # then I should see files in the correct order
-    file_order = folders.map(&:name).sort + files.map(&:name).sort
+    file_order = FileResource.where(id: folders).order(:name).pluck(:name) +
+                 FileResource.where(id: files).order(:name).pluck(:name)
     expect(page.all('.file').map(&:text)).to eq file_order
   end
 


### PR DESCRIPTION
Use SQL sorting to assert correct sort order in folders#show. This is
necessary because Ruby sorting results in a different sort order than
SQL does. See: https://stackoverflow.com/a/44271968/6451879