### PR TITLE
Add resources to profiles

### DIFF
--- a/app/assets/stylesheets/shared/cards.scss
+++ b/app/assets/stylesheets/shared/cards.scss
@@ -21,5 +21,13 @@
   // Reduce top & bottom spacing on cards
   .card-content {
     padding: 16px 24px;
+
+    p:not(:first-of-type) {
+      margin-top: 10px;
+    }
+  }
+
+  .with-bottom-seam {
+    @include seam('bottom');
   }
 }

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -13,6 +13,7 @@ class ProfilesController < ApplicationController
       .where_profile_is_owner_or_collaborator(@profile)
       .includes(:owner)
       .order(:title, :id)
+    @resources = @profile.resources
     @user_can_edit_profile = can?(:edit, @profile)
   end
 

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Controller for resources
+class ResourcesController < ApplicationController
+  # GET /resources/:id
+  def show
+    @resource = Resource.find(params[:id])
+    redirect_to @resource.link
+  end
+end

--- a/app/models/profiles/base.rb
+++ b/app/models/profiles/base.rb
@@ -22,6 +22,9 @@ module Profiles
     has_many :projects, foreign_key: :owner_id,
                         dependent: :destroy,
                         inverse_of: :owner
+    has_many :resources, foreign_key: :owner_id,
+                         dependent: :destroy,
+                         inverse_of: :owner
     has_and_belongs_to_many :collaborations, class_name: 'Project',
                                              foreign_key: 'profile_id',
                                              validate: false

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -8,4 +8,9 @@ class Resource < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :mime_type
   validates_presence_of :link
+
+  # Return the icon associated with the mime type of this resource
+  def icon
+    Providers::GoogleDrive::Icon.for(mime_type: mime_type)
+  end
 end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -2,6 +2,9 @@
 
 # A single file resource
 class Resource < ApplicationRecord
+  acts_as_hashids secret: ENV['HASH_ID_SECRET']
+
+  # Associations
   belongs_to :owner, class_name: 'Profiles::Base'
 
   # Validations

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# A single file resource
+class Resource < ApplicationRecord
+  belongs_to :owner, class_name: 'Profiles::Base'
+
+  # Validations
+  validates_presence_of :title
+  validates_presence_of :mime_type
+  validates_presence_of :link
+end

--- a/app/views/profiles/show.slim
+++ b/app/views/profiles/show.slim
@@ -69,3 +69,23 @@
                         'hide-on-med-and-up',
                         '')
           .clearfix
+
+- if @resources.present?
+  .container
+    .row.no-margin-bottom
+      .col.s12
+        h3 Resources
+    .row
+      - @resources.each do |resource|
+
+        = render resource
+
+        div class=cycle('hide-on-med-and-up',
+                        'hide-on-large-only',
+                        'hide-on-med-only',
+                        'hide-on-large-only',
+                        'hide-on-med-and-up',
+                        '')
+          .clearfix
+
+.spacing.v32px

--- a/app/views/resources/_resource.slim
+++ b/app/views/resources/_resource.slim
@@ -10,7 +10,7 @@
     .card-content.gray.lighten-4
       .row.no-margin-bottom
         .col.s12
-          = link_to resource.link, class: 'blue-text text-darken-2', target: '_blank' do
+          = link_to resource, class: 'blue-text text-darken-2', target: '_blank' do
             svg.left style="width:24px;height:24px; margin-right: 8px;" viewBox="0 0 24 24"
               path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
             b Open in Google Drive

--- a/app/views/resources/_resource.slim
+++ b/app/views/resources/_resource.slim
@@ -1,0 +1,16 @@
+.col.s12.m6.l4
+  .card
+    .card-title.truncate.black.white-text.z-depth-3 title=resource.title
+      = image_tag resource.icon, class: 'circle left', size: '34', style: 'margin-right: 8px;'
+      = resource.title
+
+    .card-content.with-bottom-seam
+      = simple_format(resource.description.presence || 'No description.')
+
+    .card-content.gray.lighten-4
+      .row.no-margin-bottom
+        .col.s12
+          = link_to resource.link, class: 'blue-text text-darken-2', target: '_blank' do
+            svg.left style="width:24px;height:24px; margin-right: 8px;" viewBox="0 0 24 24"
+              path fill="currentColor" d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+            b Open in Google Drive

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,9 @@ Rails.application.routes.draw do
   # Routes for notifications
   resources :notifications, only: %i[index show]
 
+  # Routes for resources
+  resources :resources, only: :show
+
   # Routes for creating new projects
   get   '/projects/new' => 'projects#new',    as: :new_project
   post  '/projects/new' => 'projects#create', as: :projects

--- a/db/migrate/20180414050240_create_resources.rb
+++ b/db/migrate/20180414050240_create_resources.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Add resources that belong to profiles
+class CreateResources < ActiveRecord::Migration[5.1]
+  def change
+    create_table :resources do |t|
+      t.string :title, null: false
+      t.text :description
+      t.text :mime_type, null: false
+      t.belongs_to :owner, foreign_key: { to_table: :profiles }, null: false
+      t.text :link, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180413212022) do
+ActiveRecord::Schema.define(version: 20180414050240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -229,6 +229,17 @@ ActiveRecord::Schema.define(version: 20180413212022) do
     t.index ["owner_id"], name: "index_projects_on_owner_id"
   end
 
+  create_table "resources", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "description"
+    t.text "mime_type", null: false
+    t.bigint "owner_id", null: false
+    t.text "link", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_resources_on_owner_id"
+  end
+
   create_table "revisions", force: :cascade do |t|
     t.bigint "project_id", null: false
     t.bigint "parent_id"
@@ -276,6 +287,7 @@ ActiveRecord::Schema.define(version: 20180413212022) do
   add_foreign_key "file_resources", "file_resources", column: "parent_id"
   add_foreign_key "profiles", "accounts"
   add_foreign_key "project_setups", "projects"
+  add_foreign_key "resources", "profiles", column: "owner_id"
   add_foreign_key "revisions", "profiles", column: "author_id"
   add_foreign_key "revisions", "projects"
   add_foreign_key "revisions", "revisions", column: "parent_id"

--- a/spec/controllers/resources_controller_spec.rb
+++ b/spec/controllers/resources_controller_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'controllers/shared_examples/raise_404_if_non_existent.rb'
+
+RSpec.describe ResourcesController, type: :controller do
+  describe 'GET #show' do
+    let!(:resource)   { create :resource }
+    let(:run_request) { get :show, params: { id: resource.id } }
+
+    it_should_behave_like 'raise 404 if non-existent', Resource
+
+    it 'returns http redirect' do
+      run_request
+      expect(response).to have_http_status :redirect
+    end
+  end
+end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :resource do
+    title       { Faker::File.file_name('', nil, nil, '') }
+    description { Faker::Lorem.paragraph }
+    mime_type   'application/vnd.google-apps.document'
+    association :owner, factory: :user
+    link        { Faker::Internet.url('drive.google.com') }
+  end
+end

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'models/shared_examples/acting_as_hash_id.rb'
+
 RSpec.describe Notification, type: :model do
   subject(:notification) { build_stubbed :notification }
 
@@ -7,11 +9,7 @@ RSpec.describe Notification, type: :model do
     is_expected.to be_valid
   end
 
-  describe 'hash ids' do
-    it '#to_param returns a hash id' do
-      expect(notification.to_param).to be_an_instance_of String
-    end
-  end
+  it_should_behave_like 'acting as hash ID'
 
   describe 'aliases' do
     it do

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
+require 'models/shared_examples/acting_as_hash_id.rb'
+
 RSpec.describe Resource, type: :model do
   subject(:resource) { build_stubbed :resource }
 
   it 'has a valid factory' do
     is_expected.to be_valid
   end
+
+  it_should_behave_like 'acting as hash ID'
 
   describe 'associations' do
     it { is_expected.to belong_to(:owner).dependent(false) }

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -19,4 +19,17 @@ RSpec.describe Resource, type: :model do
     end
     it { is_expected.to validate_presence_of(:link) }
   end
+
+  describe '#icon' do
+    subject { resource.icon }
+
+    before do
+      allow(Providers::GoogleDrive::Icon)
+        .to receive(:for)
+        .with(mime_type: resource.mime_type)
+        .and_return 'icon-for-mime-type'
+    end
+
+    it { is_expected.to eq 'icon-for-mime-type' }
+  end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+RSpec.describe Resource, type: :model do
+  subject(:resource) { build_stubbed :resource }
+
+  it 'has a valid factory' do
+    is_expected.to be_valid
+  end
+
+  describe 'associations' do
+    it { is_expected.to belong_to(:owner).dependent(false) }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of(:title) }
+    it { is_expected.to validate_presence_of(:mime_type) }
+    it do
+      is_expected.to validate_presence_of(:owner).with_message('must exist')
+    end
+    it { is_expected.to validate_presence_of(:link) }
+  end
+end

--- a/spec/models/shared_examples/acting_as_hash_id.rb
+++ b/spec/models/shared_examples/acting_as_hash_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'acting as hash ID' do
+  it '#to_param returns a hash id' do
+    expect(subject.to_param).to be_an_instance_of String
+  end
+end

--- a/spec/models/shared_examples/being_a_profile.rb
+++ b/spec/models/shared_examples/being_a_profile.rb
@@ -20,6 +20,13 @@ RSpec.shared_examples 'being a profile' do
     end
     it do
       is_expected
+        .to have_many(:resources)
+        .with_foreign_key(:owner_id)
+        .dependent(:destroy)
+        .inverse_of(:owner)
+    end
+    it do
+      is_expected
         .to have_and_belong_to_many(:collaborations)
         .class_name('Project').validate(false)
     end

--- a/spec/routing/resource_routing_spec.rb
+++ b/spec/routing/resource_routing_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.describe 'routes for resources', type: :routing do
+  it 'has show route' do
+    expect(resource_path('id')).to eq '/resources/id'
+    expect(get: '/resources/id').to route_to('resources#show', id: 'id')
+  end
+end

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 RSpec.describe 'profiles/show', type: :view do
-  let(:profile) { build(:user, :with_social_links) }
-  let(:projects) { build_stubbed_list(:project, 3, owner: profile) }
+  let(:profile)   { build(:user, :with_social_links) }
+  let(:projects)  { build_stubbed_list(:project, 3, owner: profile) }
+  let(:resources) { build_stubbed_list(:resource, 3, owner: profile) }
 
   before do
     assign(:profile, profile)
     assign(:projects, projects)
+    assign(:resources, resources)
   end
 
   it 'renders the name of the profile' do
@@ -47,6 +49,21 @@ RSpec.describe 'profiles/show', type: :view do
         project.title,
         href: profile_project_path(project.owner, project)
       )
+    end
+  end
+
+  it 'lists resources with title & description' do
+    render
+    resources.each do |resource|
+      expect(rendered).to have_text resource.title
+      expect(rendered).to have_text resource.description
+    end
+  end
+
+  it 'links to resources' do
+    render
+    resources.each do |resource|
+      expect(rendered).to have_link href: resource.link
     end
   end
 

--- a/spec/views/profiles/show_spec.rb
+++ b/spec/views/profiles/show_spec.rb
@@ -63,7 +63,10 @@ RSpec.describe 'profiles/show', type: :view do
   it 'links to resources' do
     render
     resources.each do |resource|
-      expect(rendered).to have_link href: resource.link
+      expect(rendered).to have_link(
+        'Open in Google Drive',
+        href: resource_path(resource)
+      )
     end
   end
 


### PR DESCRIPTION
Profiles can own resources (such as Google Drive files). Resources are listed on a profile's page. Currently, resources must be added via CLI, not in-app.